### PR TITLE
ci: Address 'semgrep' security warning

### DIFF
--- a/.github/workflows/symx-runner-ubuntu.yml
+++ b/.github/workflows/symx-runner-ubuntu.yml
@@ -61,4 +61,4 @@ jobs:
         env:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SYMX_STEP: ${{ inputs.symx_run}}
+          SYMX_STEP: ${{ inputs.symx_run }}

--- a/.github/workflows/symx-runner-ubuntu.yml
+++ b/.github/workflows/symx-runner-ubuntu.yml
@@ -57,7 +57,8 @@ jobs:
           sudo update-ca-certificates
 
       - name: ${{ inputs.symx_step }}
-        run: uv run python -m symx ${{ inputs.symx_run }}
+        run: uv run python -m symx "$SYMX_STEP"
         env:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SYMX_STEP: ${{ inputs.symx_run}}


### PR DESCRIPTION
Semgrep has created the following issue:
- https://linear.app/getsentry/issue/INGEST-414/command-injection-vulnerabilities-in-getsentrysymx-in-3-locations

This PR addresses the raised concerns using the same approach as this [PR](https://github.com/getsentry/apple-system-symbols-upload/pull/39)