### PR TITLE
fix: improve `ota extract` diagnostics

### DIFF
--- a/symx/ota/extract.py
+++ b/symx/ota/extract.py
@@ -25,6 +25,94 @@ from symx.ota.model import (
 
 logger = logging.getLogger(__name__)
 
+MAX_SUBPROCESS_OUTPUT_CHARS = 4_000
+MAX_EXTRACT_DIR_SAMPLE_ENTRIES = 20
+
+
+def _decode_subprocess_output(output: str | bytes | None) -> str:
+    if output is None:
+        return ""
+    if isinstance(output, bytes):
+        return output.decode("utf-8", errors="replace")
+    return output
+
+
+def _format_subprocess_output(label: str, output: str | bytes | None) -> str:
+    text = _decode_subprocess_output(output).strip()
+    if not text:
+        return f"  {label}: <empty>"
+
+    if len(text) > MAX_SUBPROCESS_OUTPUT_CHARS:
+        omitted = len(text) - MAX_SUBPROCESS_OUTPUT_CHARS
+        text = f"{text[:MAX_SUBPROCESS_OUTPUT_CHARS]}\n... [truncated {omitted} chars]"
+
+    indented = "\n".join(f"    {line}" for line in text.splitlines())
+    return f"  {label}:\n{indented}"
+
+
+def _format_subprocess_result(
+    label: str, result: subprocess.CompletedProcess[bytes] | subprocess.CompletedProcess[str] | None
+) -> str:
+    if result is None:
+        return f"{label}: not attempted"
+
+    return "\n".join(
+        [
+            f"{label}: exit={result.returncode}",
+            _format_subprocess_output("stdout", result.stdout),
+            _format_subprocess_output("stderr", result.stderr),
+        ]
+    )
+
+
+def _describe_extract_dirs(output_dir: Path) -> str:
+    extract_dirs = list_dirs_in(output_dir)
+    if not extract_dirs:
+        return f"No image directories were created in {output_dir}"
+
+    lines = [f"Image directories created in {output_dir}:"]
+    for extract_dir in extract_dirs:
+        lines.append(f"- {extract_dir}")
+        if _dir_contains_dsc(extract_dir):
+            lines.append(f"  contains at least one {DYLD_SHARED_CACHE}* file")
+            continue
+
+        sample_entries: list[str] = []
+        for path in extract_dir.rglob("*"):
+            suffix = "/" if path.is_dir() else ""
+            sample_entries.append(f"{path.relative_to(extract_dir)}{suffix}")
+            if len(sample_entries) >= MAX_EXTRACT_DIR_SAMPLE_ENTRIES:
+                break
+
+        if not sample_entries:
+            lines.append("  (empty)")
+            continue
+
+        lines.append("  sample entries:")
+        lines.extend(f"    {entry}" for entry in sample_entries)
+        if len(sample_entries) >= MAX_EXTRACT_DIR_SAMPLE_ENTRIES:
+            lines.append(f"    ... showing first {MAX_EXTRACT_DIR_SAMPLE_ENTRIES} entries")
+
+    return "\n".join(lines)
+
+
+def _format_extract_ota_error(
+    artifact: Path,
+    output_dir: Path,
+    reason: str,
+    literal_result: subprocess.CompletedProcess[bytes],
+    pattern_result: subprocess.CompletedProcess[bytes] | None,
+) -> str:
+    return "\n".join(
+        [
+            reason,
+            _format_subprocess_result("literal extract", literal_result),
+            _format_subprocess_result("payloadv2 pattern extract", pattern_result),
+            _describe_extract_dirs(output_dir),
+            f"artifact: {artifact}",
+        ]
+    )
+
 
 def parse_cryptex_patch_output(stderr: str) -> dict[str, Path]:
     """Parse ipsw ota patch stderr to extract DMG file mappings."""
@@ -208,7 +296,7 @@ def extract_ota(artifact: Path, output_dir: Path) -> Path | None:
         span.set_data("artifact", str(artifact))
 
         # First try the legacy approach: literal filename extraction (works for older OTAs)
-        subprocess.run(
+        literal_result = subprocess.run(
             [
                 "ipsw",
                 "ota",
@@ -220,7 +308,9 @@ def extract_ota(artifact: Path, output_dir: Path) -> Path | None:
             ],
             capture_output=True,
         )
+        span.set_data("literal_extract.returncode", literal_result.returncode)
 
+        pattern_result: subprocess.CompletedProcess[bytes] | None = None
         extract_dirs = list_dirs_in(output_dir)
         if not extract_dirs or not _dir_contains_dsc(extract_dirs[0]):
             # Fallback: modern payloadv2 OTAs (e.g. watchOS) store the DSC inside numbered payload
@@ -228,7 +318,7 @@ def extract_ota(artifact: Path, output_dir: Path) -> Path | None:
             # with -y (confirm payloadv2 search) instead.
             # Note: -d -y should work but is buggy in ipsw <=3.1.655.
             logger.info("Literal DSC extraction failed, trying payloadv2 pattern search for %s", artifact.name)
-            subprocess.run(
+            pattern_result = subprocess.run(
                 [
                     "ipsw",
                     "ota",
@@ -242,14 +332,42 @@ def extract_ota(artifact: Path, output_dir: Path) -> Path | None:
                 ],
                 capture_output=True,
             )
+            span.set_data("pattern_extract.returncode", pattern_result.returncode)
             extract_dirs = list_dirs_in(output_dir)
 
         if not extract_dirs:
             span.set_status("internal_error")
-            raise OtaExtractError(f"Could not find {DYLD_SHARED_CACHE} in {artifact}")
+            raise OtaExtractError(
+                _format_extract_ota_error(
+                    artifact,
+                    output_dir,
+                    f"Could not find {DYLD_SHARED_CACHE} in {artifact}",
+                    literal_result,
+                    pattern_result,
+                )
+            )
         elif len(extract_dirs) > 1:
-            extract_dirs_output = "\n".join([str(dir_path) for dir_path in extract_dirs])
-            raise OtaExtractError(f"Found more than one image directory in {artifact}:\n{extract_dirs_output}")
+            span.set_status("internal_error")
+            raise OtaExtractError(
+                _format_extract_ota_error(
+                    artifact,
+                    output_dir,
+                    f"Found more than one image directory in {artifact}",
+                    literal_result,
+                    pattern_result,
+                )
+            )
+        elif not _dir_contains_dsc(extract_dirs[0]):
+            span.set_status("internal_error")
+            raise OtaExtractError(
+                _format_extract_ota_error(
+                    artifact,
+                    output_dir,
+                    f"OTA extraction produced no {DYLD_SHARED_CACHE} files for {artifact}",
+                    literal_result,
+                    pattern_result,
+                )
+            )
 
         logger.info("Successfully extracted DSC from %s", artifact.name)
 

--- a/symx/ota/runners.py
+++ b/symx/ota/runners.py
@@ -232,7 +232,11 @@ class OtaExtract:
                     except OtaExtractError as e:
                         sentry_sdk.capture_exception(e)
                         logger.warning(
-                            "Failed to extract symbols from OTA %s %s %s", ota.platform, ota.version, ota.build
+                            "Failed to extract symbols from OTA %s %s %s: %s",
+                            ota.platform,
+                            ota.version,
+                            ota.build,
+                            e,
                         )
                         ota.processing_state = ArtifactProcessingState.SYMBOL_EXTRACTION_FAILED
                         ota.update_last_run()

--- a/tests/test_extract_utils.py
+++ b/tests/test_extract_utils.py
@@ -17,6 +17,7 @@ from subprocess import CompletedProcess
 
 from symx.ota.model import DSCSearchResult, OtaExtractError
 from symx.ota.extract import (
+    extract_ota,
     find_dsc,
     parse_cryptex_patch_output,
     parse_hdiutil_mount_output,
@@ -272,3 +273,49 @@ def test_find_dsc_generates_unique_split_dirs() -> None:
         assert len(results) == 2
         split_dirs = [r.split_dir for r in results]
         assert len(set(split_dirs)) == 2  # All unique
+
+
+# --- extract_ota tests ---
+
+
+def test_extract_ota_raises_detailed_error_when_no_dsc_extracted(monkeypatch: pytest.MonkeyPatch) -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_dir = Path(tmpdir) / "output"
+        image_dir = output_dir / "21A100__Device1,1"
+
+        def fake_run(args: list[str], capture_output: bool) -> CompletedProcess[bytes]:
+            image_dir.mkdir(parents=True, exist_ok=True)
+            if "-p" in args:
+                return CompletedProcess(args=args, returncode=0, stdout=b"pattern stdout", stderr=b"pattern stderr")
+            return CompletedProcess(args=args, returncode=1, stdout=b"literal stdout", stderr=b"literal stderr")
+
+        monkeypatch.setattr("symx.ota.extract.subprocess.run", fake_run)
+
+        with pytest.raises(OtaExtractError, match="OTA extraction produced no dyld_shared_cache files") as exc_info:
+            extract_ota(Path("/tmp/test.ota"), output_dir)
+
+        message = str(exc_info.value)
+        assert "literal extract: exit=1" in message
+        assert "payloadv2 pattern extract: exit=0" in message
+        assert "literal stdout" in message
+        assert "pattern stderr" in message
+        assert str(image_dir) in message
+
+
+def test_extract_ota_falls_back_to_pattern_extract(monkeypatch: pytest.MonkeyPatch) -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_dir = Path(tmpdir) / "output"
+        image_dir = output_dir / "21A100__Device1,1"
+
+        def fake_run(args: list[str], capture_output: bool) -> CompletedProcess[bytes]:
+            image_dir.mkdir(parents=True, exist_ok=True)
+            if "-p" in args:
+                dsc_dir = image_dir / "System/Library/Caches/com.apple.dyld"
+                dsc_dir.mkdir(parents=True, exist_ok=True)
+                (dsc_dir / "dyld_shared_cache_arm64e").touch()
+                return CompletedProcess(args=args, returncode=0, stdout=b"", stderr=b"")
+            return CompletedProcess(args=args, returncode=1, stdout=b"", stderr=b"literal failed")
+
+        monkeypatch.setattr("symx.ota.extract.subprocess.run", fake_run)
+
+        assert extract_ota(Path("/tmp/test.ota"), output_dir) == image_dir


### PR DESCRIPTION
- `extract_ota()` now captures the `ipsw ota extract` results for:
  - literal extract
  - `payloadv2` fallback extract
- if extraction still fails, it now raises an `OtaExtractError` with:
  - command exit codes
  - `stdout`/`stderr`
  - a sample of what was actually extracted
- it also now fails early if an image dir exists but contains no `dyld_shared_cache*` files, instead of deferring to the later generic `find_dsc()` error
- OTA extraction failures now log the exception message:
  - `Failed to extract symbols from OTA ...: <detailed error>`
- added coverage for:
  - detailed error reporting when extraction produces no DSC
  - successful fallback from literal extract to pattern extract