### PR TITLE
feat: implement admin tui

### DIFF
--- a/.github/workflows/symx-admin-apply.yml
+++ b/.github/workflows/symx-admin-apply.yml
@@ -1,0 +1,90 @@
+name: Apply admin rerun batch
+permissions:
+  actions: write
+  contents: read
+  id-token: write
+
+run-name: >-
+  Admin ${{ inputs.action || 'apply' }} (${{ inputs.store || 'unknown' }}):
+  ${{ inputs.reason || 'no reason provided' }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      store:
+        description: Store to mutate (ipsw or ota)
+        required: true
+        type: string
+      action:
+        description: Curated admin action (queue_mirror or queue_extract)
+        required: true
+        type: string
+      snapshot_id:
+        description: Local snapshot identifier the operator reviewed
+        required: true
+        type: string
+      base_generation:
+        description: Expected remote generation for the selected store
+        required: true
+        type: string
+      reason:
+        description: Operator reason for this rerun batch
+        required: true
+        type: string
+      request_json:
+        description: Serialized admin apply request payload
+        required: true
+        type: string
+
+jobs:
+  apply-admin-batch:
+    name: Apply admin rerun batch
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: write
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Auth
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          workload_identity_provider: projects/868781662168/locations/global/workloadIdentityPools/prod-github/providers/github-oidc-pool
+          service_account: symx-downloader@sac-prod-sa.iam.gserviceaccount.com
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
+        with:
+          version: ">= 363.0.0"
+
+      - name: Install dependencies
+        run: |
+          curl -LsSf --retry 6 --retry-delay 10 --retry-all-errors https://astral.sh/uv/install.sh | sh
+          echo "PATH=/home/runner/.local/bin:$PATH" >> "$GITHUB_ENV"
+          export PATH="/home/runner/.local/bin:$PATH"
+          uv --version
+          uv sync
+
+      - name: Apply admin batch
+        id: apply
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SYMX_STORE: ${{ vars.SYMX_STORE }}
+          REQUEST_JSON: ${{ inputs.request_json }}
+        run: |
+          export PATH="/home/runner/.local/bin:$PATH"
+          mkdir -p admin-apply
+          uv run python -m symx admin apply-batch \
+            --storage "$SYMX_STORE" \
+            --request-json "$REQUEST_JSON" \
+            --result-path admin-apply/symx_admin_apply_result.json
+
+      - name: Upload admin apply result
+        if: always()
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: symx-admin-apply-result
+          path: admin-apply/symx_admin_apply_result.json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "pydantic==2.12.5",
     "pandas>=3",
     "deepdiff==8.6.2",
+    "textual>=8.2.4",
 ]
 name = "symx"
 version = "0.2.0"

--- a/symx/__init__.py
+++ b/symx/__init__.py
@@ -6,6 +6,7 @@ import typer
 from sentry_sdk.integrations.logging import SentryLogsHandler
 
 from .model import github_run_id
+from .admin.app import admin_app
 from .gha.app import gha_app
 from .ipsw.app import ipsw_app
 from .ota.app import ota_app
@@ -14,6 +15,7 @@ from .sim.app import sim_app
 SENTRY_DSN = os.environ.get("SENTRY_DSN", None)
 
 app = typer.Typer()
+app.add_typer(admin_app, name="admin")
 app.add_typer(gha_app, name="gha")
 app.add_typer(ota_app, name="ota")
 app.add_typer(ipsw_app, name="ipsw")

--- a/symx/admin/actions.py
+++ b/symx/admin/actions.py
@@ -291,6 +291,6 @@ def _optional_str(value: object) -> str | None:
 
 
 def _coerce_int(value: object) -> int:
-    if not isinstance(value, (int, str)):
+    if isinstance(value, bool) or not isinstance(value, (int, str)):
         raise ValueError("Unexpected integer payload")
     return int(value)

--- a/symx/admin/actions.py
+++ b/symx/admin/actions.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, replace
+from enum import StrEnum
+from typing import cast
+
+from symx.admin.db import SnapshotInfo
+from symx.model import ArtifactProcessingState
+
+
+class AdminStore(StrEnum):
+    IPSW = "ipsw"
+    OTA = "ota"
+
+
+class AdminActionKind(StrEnum):
+    QUEUE_MIRROR = "queue_mirror"
+    QUEUE_EXTRACT = "queue_extract"
+
+
+class ApplyBatchStatus(StrEnum):
+    APPLIED = "applied"
+    APPLIED_WITH_WORKER_WARNING = "applied_with_worker_warning"
+    STALE_GENERATION = "stale_generation"
+    VALIDATION_FAILED = "validation_failed"
+    INTERNAL_ERROR = "internal_error"
+
+
+class WorkerDispatchStatus(StrEnum):
+    ALREADY_RUNNING = "already_running"
+    DISPATCHED = "dispatched"
+    DISPATCH_FAILED = "dispatch_failed"
+
+
+@dataclass(frozen=True)
+class IpswTarget:
+    artifact_key: str
+    link: str
+
+
+@dataclass(frozen=True)
+class OtaTarget:
+    ota_key: str
+
+
+AdminTarget = IpswTarget | OtaTarget
+
+
+@dataclass(frozen=True)
+class PendingBatch:
+    store: AdminStore
+    action: AdminActionKind
+    targets: tuple[AdminTarget, ...]
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class ApplyBatchRequest:
+    store: AdminStore
+    action: AdminActionKind
+    snapshot_id: str
+    base_generation: int
+    targets: tuple[AdminTarget, ...]
+    reason: str
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), separators=(",", ":"), sort_keys=True)
+
+    @classmethod
+    def from_json(cls, payload: str) -> ApplyBatchRequest:
+        raw_payload: object = json.loads(payload)
+        if not isinstance(raw_payload, dict):
+            raise ValueError("Unexpected apply batch payload")
+
+        payload_dict = cast(dict[str, object], raw_payload)
+        store = AdminStore(str(payload_dict["store"]))
+        action = AdminActionKind(str(payload_dict["action"]))
+        snapshot_id = str(payload_dict["snapshot_id"])
+        base_generation = _coerce_int(payload_dict["base_generation"])
+        reason = str(payload_dict["reason"])
+        raw_targets = payload_dict.get("targets")
+        if not isinstance(raw_targets, list):
+            raise ValueError("Unexpected targets payload")
+
+        return cls(
+            store=store,
+            action=action,
+            snapshot_id=snapshot_id,
+            base_generation=base_generation,
+            targets=_parse_targets(store, cast(list[object], raw_targets)),
+            reason=reason,
+        )
+
+
+@dataclass(frozen=True)
+class WorkerDispatchResult:
+    workflow: str
+    status: WorkerDispatchStatus
+    detail: str | None = None
+
+
+@dataclass(frozen=True)
+class ApplyBatchResult:
+    status: ApplyBatchStatus
+    store: AdminStore
+    action: AdminActionKind
+    snapshot_id: str
+    base_generation: int
+    remote_generation: int
+    targets: tuple[AdminTarget, ...]
+    reason: str
+    applied_count: int
+    message: str
+    worker: WorkerDispatchResult | None = None
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), separators=(",", ":"), sort_keys=True)
+
+    @classmethod
+    def from_json(cls, payload: str) -> ApplyBatchResult:
+        raw_payload: object = json.loads(payload)
+        if not isinstance(raw_payload, dict):
+            raise ValueError("Unexpected apply result payload")
+
+        payload_dict = cast(dict[str, object], raw_payload)
+        store = AdminStore(str(payload_dict["store"]))
+        worker_payload = payload_dict.get("worker")
+        worker: WorkerDispatchResult | None = None
+        if isinstance(worker_payload, dict):
+            worker_dict = cast(dict[str, object], worker_payload)
+            worker = WorkerDispatchResult(
+                workflow=str(worker_dict["workflow"]),
+                status=WorkerDispatchStatus(str(worker_dict["status"])),
+                detail=_optional_str(worker_dict.get("detail")),
+            )
+
+        raw_targets = payload_dict.get("targets")
+        if not isinstance(raw_targets, list):
+            raise ValueError("Unexpected targets payload")
+
+        return cls(
+            status=ApplyBatchStatus(str(payload_dict["status"])),
+            store=store,
+            action=AdminActionKind(str(payload_dict["action"])),
+            snapshot_id=str(payload_dict["snapshot_id"]),
+            base_generation=_coerce_int(payload_dict["base_generation"]),
+            remote_generation=_coerce_int(payload_dict["remote_generation"]),
+            targets=_parse_targets(store, cast(list[object], raw_targets)),
+            reason=str(payload_dict["reason"]),
+            applied_count=_coerce_int(payload_dict["applied_count"]),
+            message=str(payload_dict["message"]),
+            worker=worker,
+        )
+
+
+@dataclass(frozen=True)
+class ActionPreview:
+    allowed: bool
+    resulting_state: ArtifactProcessingState | None
+    note: str
+
+
+def add_target_to_pending_batch(batch: PendingBatch | None, target: AdminTarget) -> PendingBatch:
+    if batch is None:
+        raise ValueError("Cannot add a target without an existing batch")
+    if target in batch.targets:
+        return batch
+    return replace(batch, targets=(*batch.targets, target))
+
+
+def with_pending_batch_reason(batch: PendingBatch, reason: str) -> PendingBatch:
+    return replace(batch, reason=reason)
+
+
+def bind_pending_batch(batch: PendingBatch, snapshot_info: SnapshotInfo) -> ApplyBatchRequest:
+    reason = batch.reason.strip()
+    if not reason:
+        raise ValueError("A reason is required before applying a batch")
+
+    return ApplyBatchRequest(
+        store=batch.store,
+        action=batch.action,
+        snapshot_id=snapshot_info.snapshot_id,
+        base_generation=snapshot_generation_for_store(snapshot_info, batch.store),
+        targets=batch.targets,
+        reason=reason,
+    )
+
+
+def preview_action(
+    store: AdminStore,
+    action: AdminActionKind,
+    processing_state: ArtifactProcessingState,
+    has_required_path: bool,
+) -> ActionPreview:
+    if processing_state in _excluded_states(store):
+        return ActionPreview(False, None, f"state {processing_state.value} is excluded from curated reruns")
+
+    if action == AdminActionKind.QUEUE_EXTRACT:
+        if not has_required_path:
+            path_label = "mirror_path" if store == AdminStore.IPSW else "download_path"
+            return ActionPreview(False, None, f"{path_label} is required to queue extract")
+        resulting_state = ArtifactProcessingState.MIRRORED
+    else:
+        resulting_state = ArtifactProcessingState.INDEXED
+
+    if processing_state == resulting_state:
+        return ActionPreview(True, resulting_state, "already eligible; last_run will be refreshed")
+    return ActionPreview(True, resulting_state, f"will set state to {resulting_state.value}")
+
+
+def snapshot_generation_for_store(snapshot_info: SnapshotInfo, store: AdminStore) -> int:
+    if store == AdminStore.IPSW:
+        return snapshot_info.ipsw_generation
+    return snapshot_info.ota_generation
+
+
+def worker_workflow_for_action(store: AdminStore, action: AdminActionKind) -> str:
+    if store == AdminStore.IPSW and action == AdminActionKind.QUEUE_EXTRACT:
+        return "symx-ipsw-extract.yml"
+    if store == AdminStore.IPSW and action == AdminActionKind.QUEUE_MIRROR:
+        return "symx-ipsw-mirror.yml"
+    if store == AdminStore.OTA and action == AdminActionKind.QUEUE_EXTRACT:
+        return "symx-ota-extract.yml"
+    return "symx-ota-mirror.yml"
+
+
+def action_label(action: AdminActionKind) -> str:
+    return {
+        AdminActionKind.QUEUE_EXTRACT: "Queue extract",
+        AdminActionKind.QUEUE_MIRROR: "Queue mirror",
+    }[action]
+
+
+def target_label(target: AdminTarget) -> str:
+    if isinstance(target, IpswTarget):
+        return f"{target.artifact_key} :: {target.link}"
+    return target.ota_key
+
+
+def batch_summary(batch: PendingBatch | None) -> str:
+    if batch is None:
+        return "No pending batch. Highlight rows and press 'e' or 'm' to build one."
+
+    lines = [
+        f"store: {batch.store.value}",
+        f"action: {batch.action.value}",
+        f"reason: {batch.reason or '—'}",
+        f"targets: {len(batch.targets)}",
+    ]
+    for target in batch.targets[:8]:
+        lines.append(f"  - {target_label(target)}")
+    if len(batch.targets) > 8:
+        lines.append(f"  … and {len(batch.targets) - 8} more")
+    return "\n".join(lines)
+
+
+def _excluded_states(store: AdminStore) -> frozenset[ArtifactProcessingState]:
+    if store == AdminStore.IPSW:
+        return frozenset({ArtifactProcessingState.IGNORED})
+    return frozenset(
+        {
+            ArtifactProcessingState.IGNORED,
+            ArtifactProcessingState.INDEXED_DUPLICATE,
+            ArtifactProcessingState.DELTA_OTA,
+            ArtifactProcessingState.RECOVERY_OTA,
+        }
+    )
+
+
+def _parse_targets(store: AdminStore, raw_targets: list[object]) -> tuple[AdminTarget, ...]:
+    targets: list[AdminTarget] = []
+    for raw_target in raw_targets:
+        if not isinstance(raw_target, dict):
+            raise ValueError("Unexpected target payload")
+        payload = cast(dict[str, object], raw_target)
+        if store == AdminStore.IPSW:
+            targets.append(IpswTarget(artifact_key=str(payload["artifact_key"]), link=str(payload["link"])))
+        else:
+            targets.append(OtaTarget(ota_key=str(payload["ota_key"])))
+    return tuple(targets)
+
+
+def _optional_str(value: object) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    return str(value)
+
+
+def _coerce_int(value: object) -> int:
+    if not isinstance(value, (int, str)):
+        raise ValueError("Unexpected integer payload")
+    return int(value)

--- a/symx/admin/app/__init__.py
+++ b/symx/admin/app/__init__.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import typer
+
+from symx.admin.actions import ApplyBatchRequest, ApplyBatchStatus
+from symx.admin.db import DEFAULT_FAILURE_STATES, default_cache_dir
+from symx.admin.remote import append_apply_summary, execute_apply_request, write_apply_result
+from symx.admin.sync import AdminSyncError, run_sync
+from symx.admin.tui import launch_tui
+from symx.model import ArtifactProcessingState
+
+admin_app = typer.Typer(invoke_without_command=True, no_args_is_help=False, help="Admin TUI and local meta cache")
+
+
+@admin_app.callback(invoke_without_command=True)
+def admin_callback(
+    ctx: typer.Context,
+    cache_dir: Path = typer.Option(default_cache_dir(), "--cache-dir", help="Path to the local admin cache directory"),
+    failure_state: list[ArtifactProcessingState] = typer.Option(
+        [],
+        "--failure-state",
+        help="Processing states to include; repeat the option to narrow the tables (defaults to failure states)",
+    ),
+) -> None:
+    if ctx.invoked_subcommand is None:
+        launch_tui(cache_dir, _normalize_failure_states(failure_state))
+
+
+@admin_app.command("tui")
+def tui_command(
+    cache_dir: Path = typer.Option(default_cache_dir(), "--cache-dir", help="Path to the local admin cache directory"),
+    failure_state: list[ArtifactProcessingState] = typer.Option(
+        [],
+        "--failure-state",
+        help="Processing states to include; repeat the option to narrow the tables (defaults to failure states)",
+    ),
+) -> None:
+    launch_tui(cache_dir, _normalize_failure_states(failure_state))
+
+
+@admin_app.command("sync")
+def sync_command(
+    cache_dir: Path = typer.Option(default_cache_dir(), "--cache-dir", help="Path to the local admin cache directory"),
+) -> None:
+    try:
+        result = run_sync(cache_dir, status_callback=typer.echo)
+    except AdminSyncError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=1) from exc
+
+    snapshot_status = "new" if result.is_new_snapshot else "existing"
+    typer.echo(
+        (
+            "Done. "
+            f"snapshot={result.snapshot_id} ({snapshot_status}); "
+            f"ipsw_generation={result.ipsw_generation}; ota_generation={result.ota_generation}"
+        )
+    )
+
+
+@admin_app.command("apply-batch", hidden=True)
+def apply_batch_command(
+    storage: str = typer.Option(..., "--storage", help="GCS storage URI"),
+    request_json: str = typer.Option(..., "--request-json", help="Serialized apply request JSON"),
+    result_path: Path = typer.Option(..., "--result-path", help="Where to write the apply result JSON"),
+) -> None:
+    try:
+        request = ApplyBatchRequest.from_json(request_json)
+    except ValueError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=2) from exc
+
+    result = execute_apply_request(storage, request, status_callback=typer.echo)
+    write_apply_result(result_path, result)
+
+    step_summary = os.getenv("GITHUB_STEP_SUMMARY")
+    append_apply_summary(Path(step_summary) if step_summary else None, result)
+
+    if result.status in {ApplyBatchStatus.APPLIED, ApplyBatchStatus.APPLIED_WITH_WORKER_WARNING}:
+        return
+    raise typer.Exit(code=1)
+
+
+def _normalize_failure_states(failure_states: list[ArtifactProcessingState]) -> tuple[ArtifactProcessingState, ...]:
+    if not failure_states:
+        return DEFAULT_FAILURE_STATES
+
+    normalized = dict.fromkeys(failure_states)
+    return tuple(normalized)

--- a/symx/admin/apply.py
+++ b/symx/admin/apply.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from symx.admin.actions import AdminStore, ApplyBatchRequest, IpswTarget, OtaTarget, preview_action, target_label
+from symx.ipsw.model import IpswArtifactDb, IpswSource
+from symx.model import ArtifactProcessingState
+from symx.ota.model import OtaArtifact
+
+
+@dataclass(frozen=True)
+class ValidationIssue:
+    target: str
+    reason: str
+
+
+class AdminApplyValidationError(RuntimeError):
+    def __init__(self, issues: tuple[ValidationIssue, ...]) -> None:
+        self.issues = issues
+        super().__init__(format_validation_issues(issues))
+
+
+def apply_request_to_ipsw_db(ipsw_db: IpswArtifactDb, request: ApplyBatchRequest) -> int:
+    if request.store != AdminStore.IPSW:
+        raise ValueError("IPSW apply requested with a non-IPSW batch")
+
+    resolved_targets: list[tuple[IpswSource, ArtifactProcessingState]] = []
+    issues: list[ValidationIssue] = []
+    for target in request.targets:
+        if not isinstance(target, IpswTarget):
+            issues.append(ValidationIssue(target=target_label(target), reason="unexpected target type for ipsw batch"))
+            continue
+
+        artifact = ipsw_db.artifacts.get(target.artifact_key)
+        if artifact is None:
+            issues.append(ValidationIssue(target=target_label(target), reason="artifact not found in meta-data"))
+            continue
+
+        source = _find_ipsw_source(artifact.sources, target.link)
+        if source is None:
+            issues.append(ValidationIssue(target=target_label(target), reason="source link not found in artifact"))
+            continue
+
+        preview = preview_action(
+            AdminStore.IPSW,
+            request.action,
+            source.processing_state,
+            has_required_path=source.mirror_path is not None,
+        )
+        if not preview.allowed or preview.resulting_state is None:
+            issues.append(ValidationIssue(target=target_label(target), reason=preview.note))
+            continue
+        resolved_targets.append((source, preview.resulting_state))
+
+    if issues:
+        raise AdminApplyValidationError(tuple(issues))
+
+    for source, resulting_state in resolved_targets:
+        source.processing_state = resulting_state
+        source.update_last_run()
+
+    return len(resolved_targets)
+
+
+def apply_request_to_ota_meta(ota_meta: dict[str, OtaArtifact], request: ApplyBatchRequest) -> int:
+    if request.store != AdminStore.OTA:
+        raise ValueError("OTA apply requested with a non-OTA batch")
+
+    resolved_targets: list[tuple[OtaArtifact, ArtifactProcessingState]] = []
+    issues: list[ValidationIssue] = []
+    for target in request.targets:
+        if not isinstance(target, OtaTarget):
+            issues.append(ValidationIssue(target=target_label(target), reason="unexpected target type for ota batch"))
+            continue
+
+        artifact = ota_meta.get(target.ota_key)
+        if artifact is None:
+            issues.append(ValidationIssue(target=target_label(target), reason="ota artifact not found in meta-data"))
+            continue
+
+        preview = preview_action(
+            AdminStore.OTA,
+            request.action,
+            artifact.processing_state,
+            has_required_path=artifact.download_path is not None,
+        )
+        if not preview.allowed or preview.resulting_state is None:
+            issues.append(ValidationIssue(target=target_label(target), reason=preview.note))
+            continue
+        resolved_targets.append((artifact, preview.resulting_state))
+
+    if issues:
+        raise AdminApplyValidationError(tuple(issues))
+
+    for artifact, resulting_state in resolved_targets:
+        artifact.processing_state = resulting_state
+        artifact.update_last_run()
+
+    return len(resolved_targets)
+
+
+def format_validation_issues(issues: tuple[ValidationIssue, ...]) -> str:
+    return "; ".join(f"{issue.target}: {issue.reason}" for issue in issues)
+
+
+def _find_ipsw_source(sources: list[IpswSource], link: str) -> IpswSource | None:
+    for source in sources:
+        if str(source.link) == link:
+            return source
+    return None

--- a/symx/admin/db.py
+++ b/symx/admin/db.py
@@ -315,7 +315,7 @@ def build_snapshot_db(
                             source.processing_state.value,
                             source.mirror_path,
                             source.last_run,
-                            source.last_modified.isoformat(),
+                            source.last_modified.isoformat() if source.last_modified is not None else None,
                         ),
                     )
 

--- a/symx/admin/db.py
+++ b/symx/admin/db.py
@@ -1,0 +1,525 @@
+from __future__ import annotations
+
+import json
+import shutil
+import sqlite3
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Final, cast
+
+from symx.ipsw.model import IpswArtifactDb
+from symx.model import ArtifactProcessingState
+from symx.ota.model import OtaArtifact
+
+# Keep the default filter limited to states actively emitted by current automation.
+DEFAULT_FAILURE_STATES: Final[tuple[ArtifactProcessingState, ...]] = (
+    ArtifactProcessingState.MIRRORING_FAILED,
+    ArtifactProcessingState.MIRROR_CORRUPT,
+    ArtifactProcessingState.SYMBOL_EXTRACTION_FAILED,
+    ArtifactProcessingState.INDEXED_INVALID,
+)
+
+MANIFEST_FILE_NAME: Final[str] = "manifest.json"
+SNAPSHOT_DB_FILE_NAME: Final[str] = "snapshot.db"
+SNAPSHOTS_DIR_NAME: Final[str] = "snapshots"
+
+
+@dataclass(frozen=True)
+class SnapshotManifest:
+    active_snapshot_id: str | None = None
+
+
+@dataclass(frozen=True)
+class SnapshotPaths:
+    snapshot_id: str
+    root: Path
+    db_path: Path
+    ipsw_meta_path: Path
+    ota_meta_path: Path
+    ipsw_blob_path: Path
+    ota_blob_path: Path
+
+
+@dataclass(frozen=True)
+class SnapshotInfo:
+    snapshot_id: str
+    created_at: str
+    workflow_run_id: int | None
+    workflow_run_url: str | None
+    ipsw_generation: int
+    ota_generation: int
+
+
+@dataclass(frozen=True)
+class IpswSourceRow:
+    last_modified: str | None
+    processing_state: ArtifactProcessingState
+    platform: str
+    version: str
+    build: str
+    artifact_key: str
+    file_name: str
+    link: str
+    sha1: str | None
+    last_run: int
+    mirror_path: str | None
+
+
+@dataclass(frozen=True)
+class OtaArtifactRow:
+    last_run: int
+    processing_state: ArtifactProcessingState
+    platform: str
+    version: str
+    build: str
+    ota_key: str
+    artifact_id: str
+    url: str
+    hash: str
+    hash_algorithm: str
+    download_path: str | None
+
+
+IpswFailureRow = IpswSourceRow
+OtaFailureRow = OtaArtifactRow
+
+
+def default_cache_dir() -> Path:
+    return Path.home() / ".cache" / "symx" / "admin"
+
+
+def manifest_path(cache_dir: Path) -> Path:
+    return cache_dir / MANIFEST_FILE_NAME
+
+
+def snapshots_dir(cache_dir: Path) -> Path:
+    return cache_dir / SNAPSHOTS_DIR_NAME
+
+
+def make_snapshot_id(ipsw_generation: int, ota_generation: int) -> str:
+    return f"ipsw-{ipsw_generation}__ota-{ota_generation}"
+
+
+def snapshot_paths(cache_dir: Path, snapshot_id: str) -> SnapshotPaths:
+    root = snapshots_dir(cache_dir) / snapshot_id
+    return SnapshotPaths(
+        snapshot_id=snapshot_id,
+        root=root,
+        db_path=root / SNAPSHOT_DB_FILE_NAME,
+        ipsw_meta_path=root / "ipsw_meta.json",
+        ota_meta_path=root / "ota_image_meta.json",
+        ipsw_blob_path=root / "ipsw_meta_blob.json",
+        ota_blob_path=root / "ota_image_meta_blob.json",
+    )
+
+
+def read_manifest(cache_dir: Path) -> SnapshotManifest:
+    path = manifest_path(cache_dir)
+    if not path.exists():
+        return SnapshotManifest()
+
+    raw_payload: object = json.loads(path.read_text())
+    if not isinstance(raw_payload, dict):
+        return SnapshotManifest()
+
+    payload = cast(dict[object, object], raw_payload)
+    active_snapshot_id = payload.get("active_snapshot_id")
+    if active_snapshot_id is None:
+        return SnapshotManifest()
+    return SnapshotManifest(active_snapshot_id=str(active_snapshot_id))
+
+
+def write_manifest(cache_dir: Path, manifest: SnapshotManifest) -> None:
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path(cache_dir).write_text(json.dumps(asdict(manifest), indent=2, sort_keys=True) + "\n")
+
+
+def active_snapshot_paths(cache_dir: Path) -> SnapshotPaths | None:
+    manifest = read_manifest(cache_dir)
+    if manifest.active_snapshot_id is None:
+        return None
+
+    paths = snapshot_paths(cache_dir, manifest.active_snapshot_id)
+    if not paths.db_path.exists():
+        return None
+    return paths
+
+
+def prepare_snapshot_dir(paths: SnapshotPaths) -> None:
+    if paths.root.exists():
+        shutil.rmtree(paths.root)
+    paths.root.mkdir(parents=True, exist_ok=True)
+
+
+def connect(db_path: Path) -> sqlite3.Connection:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    init_schema(conn)
+    return conn
+
+
+def init_schema(conn: sqlite3.Connection) -> None:
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS snapshot_info (
+            id INTEGER PRIMARY KEY CHECK (id = 1),
+            snapshot_id TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            workflow_run_id INTEGER,
+            workflow_run_url TEXT,
+            ipsw_generation INTEGER NOT NULL,
+            ota_generation INTEGER NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS ipsw_artifacts (
+            artifact_key TEXT PRIMARY KEY,
+            platform TEXT NOT NULL,
+            version TEXT NOT NULL,
+            build TEXT NOT NULL,
+            released TEXT,
+            release_status TEXT NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS ipsw_sources (
+            artifact_key TEXT NOT NULL REFERENCES ipsw_artifacts(artifact_key) ON DELETE CASCADE,
+            file_name TEXT NOT NULL,
+            link TEXT NOT NULL,
+            size INTEGER,
+            sha1 TEXT,
+            sha2 TEXT,
+            devices_json TEXT NOT NULL,
+            processing_state TEXT NOT NULL,
+            mirror_path TEXT,
+            last_run INTEGER NOT NULL,
+            last_modified TEXT,
+            PRIMARY KEY (artifact_key, link)
+        );
+
+        CREATE TABLE IF NOT EXISTS ota_artifacts (
+            ota_key TEXT PRIMARY KEY,
+            build TEXT NOT NULL,
+            description_json TEXT NOT NULL,
+            version TEXT NOT NULL,
+            platform TEXT NOT NULL,
+            artifact_id TEXT NOT NULL,
+            url TEXT NOT NULL,
+            devices_json TEXT NOT NULL,
+            hash TEXT NOT NULL,
+            hash_algorithm TEXT NOT NULL,
+            processing_state TEXT NOT NULL,
+            download_path TEXT,
+            last_run INTEGER NOT NULL
+        );
+
+        CREATE INDEX IF NOT EXISTS ipsw_sources_failure_idx
+            ON ipsw_sources(processing_state, last_modified DESC);
+
+        CREATE INDEX IF NOT EXISTS ota_artifacts_failure_idx
+            ON ota_artifacts(processing_state, last_run DESC);
+        """
+    )
+
+
+def build_snapshot_db(
+    db_path: Path,
+    snapshot_id: str,
+    ipsw_db: IpswArtifactDb,
+    ipsw_generation: int,
+    ota_meta: dict[str, OtaArtifact],
+    ota_generation: int,
+    workflow_run_id: int | None,
+    workflow_run_url: str | None,
+) -> None:
+    conn = connect(db_path)
+    try:
+        with conn:
+            conn.execute("DELETE FROM snapshot_info")
+            conn.execute("DELETE FROM ipsw_sources")
+            conn.execute("DELETE FROM ipsw_artifacts")
+            conn.execute("DELETE FROM ota_artifacts")
+            conn.execute(
+                """
+                INSERT INTO snapshot_info (
+                    id,
+                    snapshot_id,
+                    created_at,
+                    workflow_run_id,
+                    workflow_run_url,
+                    ipsw_generation,
+                    ota_generation
+                )
+                VALUES (1, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    snapshot_id,
+                    datetime.now(UTC).isoformat(timespec="seconds"),
+                    workflow_run_id,
+                    workflow_run_url,
+                    ipsw_generation,
+                    ota_generation,
+                ),
+            )
+
+            for artifact in ipsw_db.artifacts.values():
+                conn.execute(
+                    """
+                    INSERT INTO ipsw_artifacts (
+                        artifact_key,
+                        platform,
+                        version,
+                        build,
+                        released,
+                        release_status
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        artifact.key,
+                        artifact.platform.value,
+                        artifact.version,
+                        artifact.build,
+                        artifact.released.isoformat() if artifact.released is not None else None,
+                        artifact.release_status.value,
+                    ),
+                )
+                for source in artifact.sources:
+                    hashes = source.hashes
+                    conn.execute(
+                        """
+                        INSERT INTO ipsw_sources (
+                            artifact_key,
+                            file_name,
+                            link,
+                            size,
+                            sha1,
+                            sha2,
+                            devices_json,
+                            processing_state,
+                            mirror_path,
+                            last_run,
+                            last_modified
+                        )
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        """,
+                        (
+                            artifact.key,
+                            source.file_name,
+                            str(source.link),
+                            source.size,
+                            hashes.sha1 if hashes is not None else None,
+                            hashes.sha2 if hashes is not None else None,
+                            json.dumps(sorted(source.devices)),
+                            source.processing_state.value,
+                            source.mirror_path,
+                            source.last_run,
+                            source.last_modified.isoformat(),
+                        ),
+                    )
+
+            for ota_key, artifact in ota_meta.items():
+                conn.execute(
+                    """
+                    INSERT INTO ota_artifacts (
+                        ota_key,
+                        build,
+                        description_json,
+                        version,
+                        platform,
+                        artifact_id,
+                        url,
+                        devices_json,
+                        hash,
+                        hash_algorithm,
+                        processing_state,
+                        download_path,
+                        last_run
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        ota_key,
+                        artifact.build,
+                        json.dumps(sorted(artifact.description)),
+                        artifact.version,
+                        artifact.platform,
+                        artifact.id,
+                        artifact.url,
+                        json.dumps(sorted(artifact.devices)),
+                        artifact.hash,
+                        artifact.hash_algorithm,
+                        artifact.processing_state.value,
+                        artifact.download_path,
+                        artifact.last_run,
+                    ),
+                )
+    finally:
+        conn.close()
+
+
+def load_snapshot_info(db_path: Path) -> SnapshotInfo | None:
+    if not db_path.exists():
+        return None
+
+    conn = connect(db_path)
+    try:
+        row = conn.execute(
+            """
+            SELECT snapshot_id, created_at, workflow_run_id, workflow_run_url, ipsw_generation, ota_generation
+            FROM snapshot_info
+            WHERE id = 1
+            """
+        ).fetchone()
+    finally:
+        conn.close()
+
+    if row is None:
+        return None
+
+    return SnapshotInfo(
+        snapshot_id=str(row["snapshot_id"]),
+        created_at=str(row["created_at"]),
+        workflow_run_id=int(row["workflow_run_id"]) if row["workflow_run_id"] is not None else None,
+        workflow_run_url=str(row["workflow_run_url"]) if row["workflow_run_url"] is not None else None,
+        ipsw_generation=int(row["ipsw_generation"]),
+        ota_generation=int(row["ota_generation"]),
+    )
+
+
+def load_ipsw_rows(
+    db_path: Path,
+    states: tuple[ArtifactProcessingState, ...] | None = None,
+    limit: int | None = None,
+) -> list[IpswSourceRow]:
+    if not db_path.exists() or states == ():
+        return []
+
+    query = """
+        SELECT
+            s.last_modified,
+            s.processing_state,
+            a.platform,
+            a.version,
+            a.build,
+            s.artifact_key,
+            s.file_name,
+            s.link,
+            s.sha1,
+            s.last_run,
+            s.mirror_path
+        FROM ipsw_sources s
+        JOIN ipsw_artifacts a ON a.artifact_key = s.artifact_key
+    """
+    params: list[str | int] = []
+    if states is not None:
+        placeholders = ", ".join("?" for _ in states)
+        query = f"{query}\nWHERE s.processing_state IN ({placeholders})"
+        params.extend(state.value for state in states)
+    query = f"{query}\nORDER BY s.last_modified DESC, s.file_name ASC"
+    if limit is not None:
+        query = f"{query}\nLIMIT ?"
+        params.append(limit)
+
+    conn = connect(db_path)
+    try:
+        rows = conn.execute(query, params).fetchall()
+    finally:
+        conn.close()
+
+    return [
+        IpswSourceRow(
+            last_modified=_str_or_none(row["last_modified"]),
+            processing_state=ArtifactProcessingState(str(row["processing_state"])),
+            platform=str(row["platform"]),
+            version=str(row["version"]),
+            build=str(row["build"]),
+            artifact_key=str(row["artifact_key"]),
+            file_name=str(row["file_name"]),
+            link=str(row["link"]),
+            sha1=_str_or_none(row["sha1"]),
+            last_run=int(row["last_run"]),
+            mirror_path=_str_or_none(row["mirror_path"]),
+        )
+        for row in rows
+    ]
+
+
+def load_ipsw_failures(
+    db_path: Path,
+    failure_states: tuple[ArtifactProcessingState, ...] = DEFAULT_FAILURE_STATES,
+    limit: int | None = None,
+) -> list[IpswSourceRow]:
+    return load_ipsw_rows(db_path, states=failure_states, limit=limit)
+
+
+def load_ota_rows(
+    db_path: Path,
+    states: tuple[ArtifactProcessingState, ...] | None = None,
+    limit: int | None = None,
+) -> list[OtaArtifactRow]:
+    if not db_path.exists() or states == ():
+        return []
+
+    query = """
+        SELECT
+            last_run,
+            processing_state,
+            platform,
+            version,
+            build,
+            ota_key,
+            artifact_id,
+            url,
+            hash,
+            hash_algorithm,
+            download_path
+        FROM ota_artifacts
+    """
+    params: list[str | int] = []
+    if states is not None:
+        placeholders = ", ".join("?" for _ in states)
+        query = f"{query}\nWHERE processing_state IN ({placeholders})"
+        params.extend(state.value for state in states)
+    query = f"{query}\nORDER BY last_run DESC, ota_key ASC"
+    if limit is not None:
+        query = f"{query}\nLIMIT ?"
+        params.append(limit)
+
+    conn = connect(db_path)
+    try:
+        rows = conn.execute(query, params).fetchall()
+    finally:
+        conn.close()
+
+    return [
+        OtaArtifactRow(
+            last_run=int(row["last_run"]),
+            processing_state=ArtifactProcessingState(str(row["processing_state"])),
+            platform=str(row["platform"]),
+            version=str(row["version"]),
+            build=str(row["build"]),
+            ota_key=str(row["ota_key"]),
+            artifact_id=str(row["artifact_id"]),
+            url=str(row["url"]),
+            hash=str(row["hash"]),
+            hash_algorithm=str(row["hash_algorithm"]),
+            download_path=_str_or_none(row["download_path"]),
+        )
+        for row in rows
+    ]
+
+
+def load_ota_failures(
+    db_path: Path,
+    failure_states: tuple[ArtifactProcessingState, ...] = DEFAULT_FAILURE_STATES,
+    limit: int | None = None,
+) -> list[OtaArtifactRow]:
+    return load_ota_rows(db_path, states=failure_states, limit=limit)
+
+
+def _str_or_none(value: object) -> str | None:
+    if value is None:
+        return None
+    return str(value)

--- a/symx/admin/downloads.py
+++ b/symx/admin/downloads.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import hashlib
+import urllib.parse
+from dataclasses import dataclass
+from collections.abc import Callable
+from pathlib import Path
+
+from symx.admin.db import IpswFailureRow, OtaFailureRow
+from symx.download import try_download_url_to_file
+from symx.fs import check_sha1
+
+DOWNLOADS_DIR_NAME = "downloads"
+StatusCallback = Callable[[str], None]
+
+
+@dataclass(frozen=True)
+class ArtifactDownloadResult:
+    path: Path
+    verified: bool
+    message: str
+
+
+class ArtifactDownloadError(RuntimeError):
+    pass
+
+
+def downloads_dir(cache_dir: Path) -> Path:
+    return cache_dir / DOWNLOADS_DIR_NAME
+
+
+def download_ipsw_to_cache(
+    row: IpswFailureRow,
+    cache_dir: Path,
+    status_callback: StatusCallback | None = None,
+) -> ArtifactDownloadResult:
+    target_dir = downloads_dir(cache_dir)
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target_path = target_dir / _ipsw_download_file_name(row)
+
+    if (
+        row.sha1 is not None
+        and target_path.exists()
+        and check_sha1(row.sha1, target_path, status_callback=status_callback)
+    ):
+        return ArtifactDownloadResult(
+            path=target_path,
+            verified=True,
+            message=f"IPSW already downloaded and SHA-1 verified: {target_path}",
+        )
+
+    temp_path = _temp_path_for(target_path)
+    temp_path.unlink(missing_ok=True)
+    try:
+        try_download_url_to_file(row.link, temp_path, status_callback=status_callback)
+        if row.sha1 is not None:
+            _emit_status("Verifying IPSW SHA-1…", status_callback)
+            if not check_sha1(row.sha1, temp_path, status_callback=status_callback):
+                raise ArtifactDownloadError(f"Downloaded IPSW failed SHA-1 verification: {row.link}")
+            verified = True
+            message = f"Downloaded and SHA-1 verified: {target_path}"
+        else:
+            verified = False
+            message = f"Downloaded without SHA verification (no sha1 in meta-data): {target_path}"
+            _emit_status(message, status_callback)
+        temp_path.replace(target_path)
+        return ArtifactDownloadResult(path=target_path, verified=verified, message=message)
+    except Exception:
+        temp_path.unlink(missing_ok=True)
+        raise
+
+
+def download_ota_to_cache(
+    row: OtaFailureRow,
+    cache_dir: Path,
+    status_callback: StatusCallback | None = None,
+) -> ArtifactDownloadResult:
+    target_dir = downloads_dir(cache_dir)
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target_path = target_dir / _ota_download_file_name(row)
+
+    if (
+        row.hash_algorithm == "SHA-1"
+        and target_path.exists()
+        and check_sha1(row.hash, target_path, status_callback=status_callback)
+    ):
+        return ArtifactDownloadResult(
+            path=target_path,
+            verified=True,
+            message=f"OTA already downloaded and SHA-1 verified: {target_path}",
+        )
+
+    temp_path = _temp_path_for(target_path)
+    temp_path.unlink(missing_ok=True)
+    try:
+        try_download_url_to_file(row.url, temp_path, status_callback=status_callback)
+        if row.hash_algorithm == "SHA-1":
+            _emit_status("Verifying OTA SHA-1…", status_callback)
+            if not check_sha1(row.hash, temp_path, status_callback=status_callback):
+                raise ArtifactDownloadError(f"Downloaded OTA failed SHA-1 verification: {row.url}")
+            verified = True
+            message = f"Downloaded and SHA-1 verified: {target_path}"
+        else:
+            verified = False
+            message = (
+                f"Downloaded without SHA verification (unsupported hash algorithm {row.hash_algorithm}): {target_path}"
+            )
+            _emit_status(message, status_callback)
+        temp_path.replace(target_path)
+        return ArtifactDownloadResult(path=target_path, verified=verified, message=message)
+    except Exception:
+        temp_path.unlink(missing_ok=True)
+        raise
+
+
+def _emit_status(message: str, status_callback: StatusCallback | None) -> None:
+    if status_callback is not None:
+        status_callback(message)
+
+
+def infer_file_name_from_url(url: str) -> str:
+    parsed = urllib.parse.urlparse(url)
+    direct_name = Path(parsed.path).name
+    query = urllib.parse.parse_qs(parsed.query)
+    query_path = query.get("path")
+    if query_path:
+        query_name = Path(query_path[0]).name
+        if query_name:
+            return query_name
+    if direct_name:
+        return direct_name
+    return "download"
+
+
+def _ipsw_download_file_name(row: IpswFailureRow) -> str:
+    source_name = infer_file_name_from_url(row.link)
+    link_hash = hashlib.sha1(row.link.encode("utf-8")).hexdigest()[:12]
+    return _safe_name(f"{row.artifact_key}__{link_hash}__{source_name}")
+
+
+def _ota_download_file_name(row: OtaFailureRow) -> str:
+    source_name = infer_file_name_from_url(row.url)
+    if not Path(source_name).suffix:
+        source_name = f"{source_name}.zip"
+    return _safe_name(f"{row.platform}_{row.version}_{row.build}_{row.artifact_id}__{source_name}")
+
+
+def _safe_name(name: str) -> str:
+    return "".join(character if character.isalnum() or character in {"-", "_", "."} else "_" for character in name)
+
+
+def _temp_path_for(path: Path) -> Path:
+    return path.with_name(f"{path.name}.part")

--- a/symx/admin/executor.py
+++ b/symx/admin/executor.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
-import json
 import subprocess
-import time
-from collections.abc import Callable
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import TypedDict, cast
 
+from symx.admin import gh_workflows
 from symx.admin.actions import ApplyBatchRequest, ApplyBatchResult
+from symx.admin.gh_workflows import StatusCallback, WorkflowRun
 
 ADMIN_APPLY_WORKFLOW = "symx-admin-apply.yml"
 ADMIN_APPLY_ARTIFACT = "symx-admin-apply-result"
@@ -17,28 +15,6 @@ ADMIN_APPLY_RESULT_FILE = "symx_admin_apply_result.json"
 
 class AdminApplyError(RuntimeError):
     pass
-
-
-class WorkflowRun(TypedDict):
-    databaseId: int
-    status: str
-    conclusion: str | None
-    url: str
-    startedAt: str | None
-    updatedAt: str | None
-    displayTitle: str
-    event: str
-
-
-class WorkflowArtifact(TypedDict, total=False):
-    name: str
-
-
-class WorkflowArtifactList(TypedDict):
-    artifacts: list[WorkflowArtifact]
-
-
-StatusCallback = Callable[[str], None]
 
 
 def run_apply(request: ApplyBatchRequest, status_callback: StatusCallback | None = None) -> ApplyBatchResult:
@@ -95,20 +71,11 @@ def _workflow_dispatch_args(request: ApplyBatchRequest) -> list[str]:
 
 
 def _status(status_callback: StatusCallback | None, message: str) -> None:
-    if status_callback is not None:
-        status_callback(message)
+    gh_workflows.emit_status(status_callback, message)
 
 
 def _wait_for_new_run(workflow: str, before_max_run_id: int) -> WorkflowRun:
-    deadline = time.monotonic() + 120.0
-    while time.monotonic() < deadline:
-        runs = _list_workflow_runs(workflow, limit=10)
-        new_runs = [run for run in runs if int(run["databaseId"]) > before_max_run_id]
-        if new_runs:
-            return max(new_runs, key=lambda run: int(run["databaseId"]))
-        time.sleep(2.0)
-
-    raise AdminApplyError(f"Timed out waiting for a new workflow run for {workflow}")
+    return gh_workflows.wait_for_new_run(workflow, before_max_run_id, AdminApplyError, _list_workflow_runs)
 
 
 def _wait_for_run_completion(
@@ -116,76 +83,23 @@ def _wait_for_run_completion(
     run_id: int,
     status_callback: StatusCallback | None,
 ) -> WorkflowRun:
-    deadline = time.monotonic() + 3600.0
-    last_status: tuple[str, str | None] | None = None
-
-    while time.monotonic() < deadline:
-        runs = _list_workflow_runs(workflow, limit=20)
-        matching_run = next((run for run in runs if int(run["databaseId"]) == run_id), None)
-        if matching_run is None:
-            time.sleep(5.0)
-            continue
-
-        status = str(matching_run["status"])
-        conclusion = matching_run["conclusion"]
-        current_status = (status, conclusion)
-        if current_status != last_status:
-            if status == "completed":
-                _status(status_callback, f"Workflow #{run_id} completed with conclusion={conclusion}")
-            else:
-                _status(status_callback, f"Workflow #{run_id} status={status}")
-            last_status = current_status
-
-        if status == "completed":
-            return matching_run
-
-        time.sleep(5.0)
-
-    raise AdminApplyError(f"Timed out waiting for workflow run #{run_id} to complete")
+    return gh_workflows.wait_for_run_completion(workflow, run_id, status_callback, AdminApplyError, _list_workflow_runs)
 
 
 def _list_workflow_runs(workflow: str, limit: int) -> list[WorkflowRun]:
-    result = _run_gh_command(
-        [
-            "run",
-            "list",
-            "--workflow",
-            workflow,
-            "--limit",
-            str(limit),
-            "--json",
-            "databaseId,status,conclusion,url,startedAt,updatedAt,displayTitle,event",
-        ]
-    )
-    raw_payload: object = json.loads(result.stdout)
-    if not isinstance(raw_payload, list):
-        raise AdminApplyError(f"Unexpected workflow run payload for {workflow}")
-    return cast(list[WorkflowRun], raw_payload)
+    return gh_workflows.list_workflow_runs(workflow, limit, AdminApplyError, _run_gh_command)
 
 
 def _max_run_id(runs: list[WorkflowRun]) -> int:
-    if not runs:
-        return 0
-    return max(int(run["databaseId"]) for run in runs)
+    return gh_workflows.max_run_id(runs)
 
 
 def _run_has_artifact(run_id: int, artifact_name: str) -> bool:
-    result = _run_gh_command(["api", f"repos/{{owner}}/{{repo}}/actions/runs/{run_id}/artifacts"])
-    raw_payload: object = json.loads(result.stdout)
-    if not isinstance(raw_payload, dict):
-        raise AdminApplyError(f"Unexpected artifact payload for run #{run_id}")
-
-    payload = cast(WorkflowArtifactList, raw_payload)
-    return any(artifact.get("name") == artifact_name for artifact in payload.get("artifacts", []))
+    return gh_workflows.run_has_artifact(run_id, artifact_name, AdminApplyError, _run_gh_command)
 
 
 def _run_gh_command(args: list[str]) -> subprocess.CompletedProcess[str]:
-    cmd = ["gh", *args]
-    result = subprocess.run(cmd, capture_output=True, text=True)
-    if result.returncode != 0:
-        stderr = result.stderr.strip() or result.stdout.strip() or "unknown gh error"
-        raise AdminApplyError(f"gh command failed: {' '.join(cmd)}\n{stderr}")
-    return result
+    return gh_workflows.run_gh_command(args, AdminApplyError)
 
 
 def _load_apply_result(download_dir: Path) -> ApplyBatchResult:
@@ -194,7 +108,4 @@ def _load_apply_result(download_dir: Path) -> ApplyBatchResult:
 
 
 def _find_single_file(root: Path, file_name: str) -> Path:
-    matches = list(root.rglob(file_name))
-    if len(matches) != 1:
-        raise AdminApplyError(f"Expected exactly one {file_name} in {root}, found {len(matches)}")
-    return matches[0]
+    return gh_workflows.find_single_file(root, file_name, AdminApplyError)

--- a/symx/admin/executor.py
+++ b/symx/admin/executor.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+from collections.abc import Callable
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import TypedDict, cast
+
+from symx.admin.actions import ApplyBatchRequest, ApplyBatchResult
+
+ADMIN_APPLY_WORKFLOW = "symx-admin-apply.yml"
+ADMIN_APPLY_ARTIFACT = "symx-admin-apply-result"
+ADMIN_APPLY_RESULT_FILE = "symx_admin_apply_result.json"
+
+
+class AdminApplyError(RuntimeError):
+    pass
+
+
+class WorkflowRun(TypedDict):
+    databaseId: int
+    status: str
+    conclusion: str | None
+    url: str
+    startedAt: str | None
+    updatedAt: str | None
+    displayTitle: str
+    event: str
+
+
+class WorkflowArtifact(TypedDict, total=False):
+    name: str
+
+
+class WorkflowArtifactList(TypedDict):
+    artifacts: list[WorkflowArtifact]
+
+
+StatusCallback = Callable[[str], None]
+
+
+def run_apply(request: ApplyBatchRequest, status_callback: StatusCallback | None = None) -> ApplyBatchResult:
+    _status(status_callback, f"Checking existing workflow runs for {ADMIN_APPLY_WORKFLOW}…")
+    before_max_run_id = _max_run_id(_list_workflow_runs(ADMIN_APPLY_WORKFLOW, limit=10))
+
+    _status(status_callback, f"Dispatching {ADMIN_APPLY_WORKFLOW}…")
+    _run_gh_command(_workflow_dispatch_args(request))
+
+    _status(status_callback, "Waiting for the new admin apply workflow run to appear…")
+    run = _wait_for_new_run(ADMIN_APPLY_WORKFLOW, before_max_run_id)
+    run_id = int(run["databaseId"])
+    run_url = str(run["url"])
+    _status(status_callback, f"Admin apply workflow run started: #{run_id}")
+
+    completed_run = _wait_for_run_completion(ADMIN_APPLY_WORKFLOW, run_id, status_callback)
+    conclusion = completed_run.get("conclusion")
+
+    if not _run_has_artifact(run_id, ADMIN_APPLY_ARTIFACT):
+        raise AdminApplyError(
+            f"Admin apply workflow finished without a result artifact ({conclusion or 'unknown'}): {run_url}"
+        )
+
+    with TemporaryDirectory(prefix="symx_admin_apply_") as temp_dir:
+        download_dir = Path(temp_dir)
+        _status(status_callback, f"Downloading admin apply artifact to {download_dir}…")
+        _run_gh_command(["run", "download", str(run_id), "--name", ADMIN_APPLY_ARTIFACT, "--dir", str(download_dir)])
+        result = _load_apply_result(download_dir)
+
+    if conclusion not in {"success", "failure"}:
+        raise AdminApplyError(f"Admin apply workflow ended unexpectedly ({conclusion or 'unknown'}): {run_url}")
+
+    return result
+
+
+def _workflow_dispatch_args(request: ApplyBatchRequest) -> list[str]:
+    return [
+        "workflow",
+        "run",
+        ADMIN_APPLY_WORKFLOW,
+        "-f",
+        f"store={request.store.value}",
+        "-f",
+        f"action={request.action.value}",
+        "-f",
+        f"snapshot_id={request.snapshot_id}",
+        "-f",
+        f"base_generation={request.base_generation}",
+        "-f",
+        f"reason={request.reason}",
+        "-f",
+        f"request_json={request.to_json()}",
+    ]
+
+
+def _status(status_callback: StatusCallback | None, message: str) -> None:
+    if status_callback is not None:
+        status_callback(message)
+
+
+def _wait_for_new_run(workflow: str, before_max_run_id: int) -> WorkflowRun:
+    deadline = time.monotonic() + 120.0
+    while time.monotonic() < deadline:
+        runs = _list_workflow_runs(workflow, limit=10)
+        new_runs = [run for run in runs if int(run["databaseId"]) > before_max_run_id]
+        if new_runs:
+            return max(new_runs, key=lambda run: int(run["databaseId"]))
+        time.sleep(2.0)
+
+    raise AdminApplyError(f"Timed out waiting for a new workflow run for {workflow}")
+
+
+def _wait_for_run_completion(
+    workflow: str,
+    run_id: int,
+    status_callback: StatusCallback | None,
+) -> WorkflowRun:
+    deadline = time.monotonic() + 3600.0
+    last_status: tuple[str, str | None] | None = None
+
+    while time.monotonic() < deadline:
+        runs = _list_workflow_runs(workflow, limit=20)
+        matching_run = next((run for run in runs if int(run["databaseId"]) == run_id), None)
+        if matching_run is None:
+            time.sleep(5.0)
+            continue
+
+        status = str(matching_run["status"])
+        conclusion = matching_run["conclusion"]
+        current_status = (status, conclusion)
+        if current_status != last_status:
+            if status == "completed":
+                _status(status_callback, f"Workflow #{run_id} completed with conclusion={conclusion}")
+            else:
+                _status(status_callback, f"Workflow #{run_id} status={status}")
+            last_status = current_status
+
+        if status == "completed":
+            return matching_run
+
+        time.sleep(5.0)
+
+    raise AdminApplyError(f"Timed out waiting for workflow run #{run_id} to complete")
+
+
+def _list_workflow_runs(workflow: str, limit: int) -> list[WorkflowRun]:
+    result = _run_gh_command(
+        [
+            "run",
+            "list",
+            "--workflow",
+            workflow,
+            "--limit",
+            str(limit),
+            "--json",
+            "databaseId,status,conclusion,url,startedAt,updatedAt,displayTitle,event",
+        ]
+    )
+    raw_payload: object = json.loads(result.stdout)
+    if not isinstance(raw_payload, list):
+        raise AdminApplyError(f"Unexpected workflow run payload for {workflow}")
+    return cast(list[WorkflowRun], raw_payload)
+
+
+def _max_run_id(runs: list[WorkflowRun]) -> int:
+    if not runs:
+        return 0
+    return max(int(run["databaseId"]) for run in runs)
+
+
+def _run_has_artifact(run_id: int, artifact_name: str) -> bool:
+    result = _run_gh_command(["api", f"repos/{{owner}}/{{repo}}/actions/runs/{run_id}/artifacts"])
+    raw_payload: object = json.loads(result.stdout)
+    if not isinstance(raw_payload, dict):
+        raise AdminApplyError(f"Unexpected artifact payload for run #{run_id}")
+
+    payload = cast(WorkflowArtifactList, raw_payload)
+    return any(artifact.get("name") == artifact_name for artifact in payload.get("artifacts", []))
+
+
+def _run_gh_command(args: list[str]) -> subprocess.CompletedProcess[str]:
+    cmd = ["gh", *args]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        stderr = result.stderr.strip() or result.stdout.strip() or "unknown gh error"
+        raise AdminApplyError(f"gh command failed: {' '.join(cmd)}\n{stderr}")
+    return result
+
+
+def _load_apply_result(download_dir: Path) -> ApplyBatchResult:
+    result_path = _find_single_file(download_dir, ADMIN_APPLY_RESULT_FILE)
+    return ApplyBatchResult.from_json(result_path.read_text())
+
+
+def _find_single_file(root: Path, file_name: str) -> Path:
+    matches = list(root.rglob(file_name))
+    if len(matches) != 1:
+        raise AdminApplyError(f"Expected exactly one {file_name} in {root}, found {len(matches)}")
+    return matches[0]

--- a/symx/admin/gh_workflows.py
+++ b/symx/admin/gh_workflows.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import TypedDict, cast
+
+
+class WorkflowRun(TypedDict):
+    databaseId: int
+    status: str
+    conclusion: str | None
+    url: str
+    startedAt: str | None
+    updatedAt: str | None
+    displayTitle: str
+    event: str
+
+
+class WorkflowArtifact(TypedDict, total=False):
+    name: str
+
+
+class WorkflowArtifactList(TypedDict):
+    artifacts: list[WorkflowArtifact]
+
+
+StatusCallback = Callable[[str], None]
+ErrorFactory = Callable[[str], Exception]
+RunGhCommand = Callable[[list[str]], subprocess.CompletedProcess[str]]
+ListWorkflowRuns = Callable[[str, int], list[WorkflowRun]]
+
+
+def emit_status(status_callback: StatusCallback | None, message: str) -> None:
+    if status_callback is not None:
+        status_callback(message)
+
+
+def wait_for_new_run(
+    workflow: str,
+    before_max_run_id: int,
+    error_factory: ErrorFactory,
+    list_workflow_runs_func: ListWorkflowRuns | None = None,
+) -> WorkflowRun:
+    deadline = time.monotonic() + 120.0
+    list_runs = list_workflow_runs_func or _list_workflow_runs_for_error(error_factory)
+    while time.monotonic() < deadline:
+        runs = list_runs(workflow, 10)
+        new_runs = [run for run in runs if int(run["databaseId"]) > before_max_run_id]
+        if new_runs:
+            return max(new_runs, key=lambda run: int(run["databaseId"]))
+        time.sleep(2.0)
+
+    raise error_factory(f"Timed out waiting for a new workflow run for {workflow}")
+
+
+def wait_for_run_completion(
+    workflow: str,
+    run_id: int,
+    status_callback: StatusCallback | None,
+    error_factory: ErrorFactory,
+    list_workflow_runs_func: ListWorkflowRuns | None = None,
+) -> WorkflowRun:
+    deadline = time.monotonic() + 3600.0
+    last_status: tuple[str, str | None] | None = None
+    list_runs = list_workflow_runs_func or _list_workflow_runs_for_error(error_factory)
+
+    while time.monotonic() < deadline:
+        runs = list_runs(workflow, 20)
+        matching_run = next((run for run in runs if int(run["databaseId"]) == run_id), None)
+        if matching_run is None:
+            time.sleep(5.0)
+            continue
+
+        status = str(matching_run["status"])
+        conclusion = matching_run["conclusion"]
+        current_status = (status, conclusion)
+        if current_status != last_status:
+            if status == "completed":
+                emit_status(status_callback, f"Workflow #{run_id} completed with conclusion={conclusion}")
+            else:
+                emit_status(status_callback, f"Workflow #{run_id} status={status}")
+            last_status = current_status
+
+        if status == "completed":
+            return matching_run
+
+        time.sleep(5.0)
+
+    raise error_factory(f"Timed out waiting for workflow run #{run_id} to complete")
+
+
+def list_workflow_runs(
+    workflow: str,
+    limit: int,
+    error_factory: ErrorFactory,
+    run_gh_command_func: RunGhCommand | None = None,
+) -> list[WorkflowRun]:
+    run_command = run_gh_command_func or _run_gh_command_for_error(error_factory)
+    result = run_command(
+        [
+            "run",
+            "list",
+            "--workflow",
+            workflow,
+            "--limit",
+            str(limit),
+            "--json",
+            "databaseId,status,conclusion,url,startedAt,updatedAt,displayTitle,event",
+        ]
+    )
+    raw_payload: object = json.loads(result.stdout)
+    if not isinstance(raw_payload, list):
+        raise error_factory(f"Unexpected workflow run payload for {workflow}")
+    return cast(list[WorkflowRun], raw_payload)
+
+
+def max_run_id(runs: list[WorkflowRun]) -> int:
+    if not runs:
+        return 0
+    return max(int(run["databaseId"]) for run in runs)
+
+
+def run_has_artifact(
+    run_id: int,
+    artifact_name: str,
+    error_factory: ErrorFactory,
+    run_gh_command_func: RunGhCommand | None = None,
+) -> bool:
+    run_command = run_gh_command_func or _run_gh_command_for_error(error_factory)
+    result = run_command(["api", f"repos/{{owner}}/{{repo}}/actions/runs/{run_id}/artifacts"])
+    raw_payload: object = json.loads(result.stdout)
+    if not isinstance(raw_payload, dict):
+        raise error_factory(f"Unexpected artifact payload for run #{run_id}")
+
+    payload = cast(WorkflowArtifactList, raw_payload)
+    return any(artifact.get("name") == artifact_name for artifact in payload.get("artifacts", []))
+
+
+def run_gh_command(args: list[str], error_factory: ErrorFactory) -> subprocess.CompletedProcess[str]:
+    cmd = ["gh", *args]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        stderr = result.stderr.strip() or result.stdout.strip() or "unknown gh error"
+        raise error_factory(f"gh command failed: {' '.join(cmd)}\n{stderr}")
+    return result
+
+
+def find_single_file(root: Path, file_name: str, error_factory: ErrorFactory) -> Path:
+    matches = list(root.rglob(file_name))
+    if len(matches) != 1:
+        raise error_factory(f"Expected exactly one {file_name} in {root}, found {len(matches)}")
+    return matches[0]
+
+
+def _list_workflow_runs_for_error(error_factory: ErrorFactory) -> ListWorkflowRuns:
+    def _inner(workflow_name: str, limit: int) -> list[WorkflowRun]:
+        return list_workflow_runs(workflow_name, limit, error_factory)
+
+    return _inner
+
+
+def _run_gh_command_for_error(error_factory: ErrorFactory) -> RunGhCommand:
+    def _inner(args: list[str]) -> subprocess.CompletedProcess[str]:
+        return run_gh_command(args, error_factory)
+
+    return _inner

--- a/symx/admin/github.py
+++ b/symx/admin/github.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from collections.abc import Callable, Iterable
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Final, TypedDict, cast
+
+GITHUB_RUN_CACHE_FILE_NAME: Final[str] = "github_runs.json"
+
+
+class GithubRunLookupError(RuntimeError):
+    pass
+
+
+class GithubRunPayload(TypedDict):
+    databaseId: int
+    startedAt: str | None
+    updatedAt: str | None
+    url: str | None
+    status: str | None
+    conclusion: str | None
+    displayTitle: str | None
+
+
+@dataclass(frozen=True)
+class GithubRunInfo:
+    run_id: int
+    started_at: str | None = None
+    updated_at: str | None = None
+    url: str | None = None
+    status: str | None = None
+    conclusion: str | None = None
+    display_title: str | None = None
+
+    @property
+    def best_timestamp(self) -> str | None:
+        return self.updated_at or self.started_at
+
+
+StatusCallback = Callable[[str], None]
+
+
+def github_run_cache_path(cache_dir: Path) -> Path:
+    return cache_dir / GITHUB_RUN_CACHE_FILE_NAME
+
+
+def read_github_run_cache(cache_dir: Path) -> dict[int, GithubRunInfo]:
+    path = github_run_cache_path(cache_dir)
+    if not path.exists():
+        return {}
+
+    raw_payload: object = json.loads(path.read_text())
+    if not isinstance(raw_payload, dict):
+        return {}
+
+    payload = cast(dict[object, object], raw_payload)
+    result: dict[int, GithubRunInfo] = {}
+    for key, value in payload.items():
+        if not isinstance(key, str) or not isinstance(value, dict):
+            continue
+        try:
+            run_id = int(key)
+        except ValueError:
+            continue
+        value_dict = cast(dict[object, object], value)
+        result[run_id] = GithubRunInfo(
+            run_id=run_id,
+            started_at=_optional_str(value_dict.get("started_at")),
+            updated_at=_optional_str(value_dict.get("updated_at")),
+            url=_optional_str(value_dict.get("url")),
+            status=_optional_str(value_dict.get("status")),
+            conclusion=_optional_str(value_dict.get("conclusion")),
+            display_title=_optional_str(value_dict.get("display_title")),
+        )
+    return result
+
+
+def write_github_run_cache(cache_dir: Path, run_infos: dict[int, GithubRunInfo]) -> None:
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    payload = {str(run_id): asdict(info) for run_id, info in sorted(run_infos.items())}
+    github_run_cache_path(cache_dir).write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def ensure_github_run_infos(
+    cache_dir: Path,
+    run_ids: Iterable[int],
+    status_callback: StatusCallback | None = None,
+) -> dict[int, GithubRunInfo]:
+    cache = read_github_run_cache(cache_dir)
+    missing_run_ids = sorted({run_id for run_id in run_ids if run_id not in cache and run_id > 0})
+
+    for run_id in missing_run_ids:
+        try:
+            info = fetch_github_run_info(run_id)
+        except GithubRunLookupError as exc:
+            if status_callback is not None:
+                status_callback(f"Failed to resolve GitHub run #{run_id}: {exc}")
+            continue
+        cache[run_id] = info
+
+    if missing_run_ids:
+        write_github_run_cache(cache_dir, cache)
+
+    return cache
+
+
+def fetch_github_run_info(run_id: int) -> GithubRunInfo:
+    result = subprocess.run(
+        [
+            "gh",
+            "run",
+            "view",
+            str(run_id),
+            "--json",
+            "databaseId,startedAt,updatedAt,url,status,conclusion,displayTitle",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        stderr = result.stderr.strip() or result.stdout.strip() or "unknown gh error"
+        raise GithubRunLookupError(stderr)
+
+    raw_payload: object = json.loads(result.stdout)
+    if not isinstance(raw_payload, dict):
+        raise GithubRunLookupError("Unexpected gh run payload")
+
+    payload = cast(GithubRunPayload, raw_payload)
+    return GithubRunInfo(
+        run_id=int(payload["databaseId"]),
+        started_at=payload["startedAt"],
+        updated_at=payload["updatedAt"],
+        url=payload["url"],
+        status=payload["status"],
+        conclusion=payload["conclusion"],
+        display_title=payload["displayTitle"],
+    )
+
+
+def format_github_run_time(run_id: int, run_info: GithubRunInfo | None) -> str:
+    if run_info is None or run_info.best_timestamp is None:
+        return f"#{run_id}"
+    return format_iso_timestamp(run_info.best_timestamp)
+
+
+def format_iso_timestamp(timestamp: str) -> str:
+    dt = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+    return dt.astimezone(UTC).strftime("%Y-%m-%d %H:%MZ")
+
+
+def _optional_str(value: object) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    return str(value)

--- a/symx/admin/meta_json.py
+++ b/symx/admin/meta_json.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import Any, cast
+
+from symx.ota.model import OtaArtifact
+
+ErrorFactory = Callable[[str], Exception]
+
+
+def parse_ota_meta_json(raw_json: str, error_factory: ErrorFactory) -> dict[str, OtaArtifact]:
+    raw_payload: object = json.loads(raw_json)
+    if not isinstance(raw_payload, dict):
+        raise error_factory("Unexpected OTA meta-data payload")
+
+    ota_payload = cast(dict[object, object], raw_payload)
+    result: dict[str, OtaArtifact] = {}
+    for key, value in ota_payload.items():
+        if not isinstance(key, str):
+            raise error_factory("Unexpected OTA meta-data key type")
+        if not isinstance(value, dict):
+            raise error_factory("Unexpected OTA meta-data value type")
+        result[key] = OtaArtifact(**cast(dict[str, Any], value))
+    return result

--- a/symx/admin/remote.py
+++ b/symx/admin/remote.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import subprocess
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any, cast
@@ -19,6 +18,8 @@ from symx.admin.actions import (
     worker_workflow_for_action,
 )
 from symx.admin.apply import AdminApplyValidationError, apply_request_to_ipsw_db, apply_request_to_ota_meta
+from symx.admin.meta_json import parse_ota_meta_json
+from symx.admin import gh_workflows
 from symx.gcs import parse_gcs_url
 from symx.ipsw.model import ARTIFACTS_META_JSON as IPSW_META_JSON, IpswArtifactDb
 from symx.ota.model import ARTIFACTS_META_JSON as OTA_META_JSON, OtaArtifact
@@ -139,7 +140,7 @@ def ensure_worker_running(
 
     _status(status_callback, f"Dispatching {workflow}…")
     try:
-        _run_gh_command(["workflow", "run", workflow])
+        gh_workflows.run_gh_command(["workflow", "run", workflow], AdminRemoteApplyError)
     except AdminRemoteApplyError as exc:
         return WorkerDispatchResult(workflow=workflow, status=WorkerDispatchStatus.DISPATCH_FAILED, detail=str(exc))
 
@@ -175,7 +176,10 @@ def append_apply_summary(summary_path: Path | None, result: ApplyBatchResult) ->
                 f"- worker detail: {result.worker.detail or '—'}",
             ]
         )
-    summary_path.write_text("\n".join(lines) + "\n")
+    existing_prefix = "\n" if summary_path.exists() and summary_path.stat().st_size > 0 else ""
+    with summary_path.open("a", encoding="utf-8") as summary_file:
+        summary_file.write(existing_prefix)
+        summary_file.write("\n".join(lines) + "\n")
 
 
 def _bucket_for_storage(storage: str) -> Bucket:
@@ -207,23 +211,11 @@ def _load_ipsw_db(blob: Blob) -> IpswArtifactDb:
 
 def _load_ota_meta(blob: Blob) -> dict[str, OtaArtifact]:
     raw_json = str(cast(Any, blob).download_as_text())
-    raw_payload: object = json.loads(raw_json)
-    if not isinstance(raw_payload, dict):
-        raise AdminRemoteApplyError("Unexpected OTA meta-data payload")
-
-    ota_payload = cast(dict[object, object], raw_payload)
-    result: dict[str, OtaArtifact] = {}
-    for key, value in ota_payload.items():
-        if not isinstance(key, str):
-            raise AdminRemoteApplyError("Unexpected OTA meta-data key type")
-        if not isinstance(value, dict):
-            raise AdminRemoteApplyError("Unexpected OTA meta-data value type")
-        result[key] = OtaArtifact(**cast(dict[str, Any], value))
-    return result
+    return parse_ota_meta_json(raw_json, AdminRemoteApplyError)
 
 
 def _list_workflow_runs(workflow: str, limit: int = 10) -> list[dict[str, object]]:
-    result = _run_gh_command(
+    result = gh_workflows.run_gh_command(
         [
             "run",
             "list",
@@ -233,21 +225,13 @@ def _list_workflow_runs(workflow: str, limit: int = 10) -> list[dict[str, object
             str(limit),
             "--json",
             "databaseId,status,url",
-        ]
+        ],
+        AdminRemoteApplyError,
     )
     raw_payload: object = json.loads(result.stdout)
     if not isinstance(raw_payload, list):
         raise AdminRemoteApplyError(f"Unexpected workflow run payload for {workflow}")
     return cast(list[dict[str, object]], raw_payload)
-
-
-def _run_gh_command(args: list[str]) -> subprocess.CompletedProcess[str]:
-    cmd = ["gh", *args]
-    result = subprocess.run(cmd, capture_output=True, text=True)
-    if result.returncode != 0:
-        stderr = result.stderr.strip() or result.stdout.strip() or "unknown gh error"
-        raise AdminRemoteApplyError(f"gh command failed: {' '.join(cmd)}\n{stderr}")
-    return result
 
 
 def _result(

--- a/symx/admin/remote.py
+++ b/symx/admin/remote.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, cast
+
+from google.api_core.exceptions import PreconditionFailed
+from google.cloud.storage import Blob, Bucket, Client
+
+from symx.admin.actions import (
+    AdminStore,
+    ApplyBatchRequest,
+    ApplyBatchResult,
+    ApplyBatchStatus,
+    WorkerDispatchResult,
+    WorkerDispatchStatus,
+    worker_workflow_for_action,
+)
+from symx.admin.apply import AdminApplyValidationError, apply_request_to_ipsw_db, apply_request_to_ota_meta
+from symx.gcs import parse_gcs_url
+from symx.ipsw.model import ARTIFACTS_META_JSON as IPSW_META_JSON, IpswArtifactDb
+from symx.ota.model import ARTIFACTS_META_JSON as OTA_META_JSON, OtaArtifact
+
+StatusCallback = Callable[[str], None]
+
+
+class AdminRemoteApplyError(RuntimeError):
+    pass
+
+
+def execute_apply_request(
+    storage: str,
+    request: ApplyBatchRequest,
+    status_callback: StatusCallback | None = None,
+) -> ApplyBatchResult:
+    try:
+        bucket = _bucket_for_storage(storage)
+        blob = bucket.blob(_meta_blob_name(request.store))
+        remote_generation = _blob_generation(blob)
+        _status(status_callback, f"Remote {request.store.value} generation is {remote_generation}.")
+        if remote_generation != request.base_generation:
+            return _result(
+                request,
+                status=ApplyBatchStatus.STALE_GENERATION,
+                remote_generation=remote_generation,
+                applied_count=0,
+                message=(
+                    f"Refusing to apply against stale generation: local={request.base_generation}, remote={remote_generation}"
+                ),
+            )
+
+        if request.store == AdminStore.IPSW:
+            ipsw_db = _load_ipsw_db(blob)
+            applied_count = apply_request_to_ipsw_db(ipsw_db, request)
+            serialized_payload = ipsw_db.model_dump_json()
+        else:
+            ota_meta = _load_ota_meta(blob)
+            applied_count = apply_request_to_ota_meta(ota_meta, request)
+            serialized_payload = json.dumps({key: value.model_dump() for key, value in ota_meta.items()})
+    except AdminApplyValidationError as exc:
+        return _result(
+            request,
+            status=ApplyBatchStatus.VALIDATION_FAILED,
+            remote_generation=request.base_generation,
+            applied_count=0,
+            message=str(exc),
+        )
+    except Exception as exc:  # pragma: no cover - defensive guard around remote execution
+        return _result(
+            request,
+            status=ApplyBatchStatus.INTERNAL_ERROR,
+            remote_generation=request.base_generation,
+            applied_count=0,
+            message=str(exc),
+        )
+
+    _status(
+        status_callback,
+        f"Uploading updated {request.store.value} meta-data with generation match {request.base_generation}…",
+    )
+    try:
+        blob.upload_from_string(serialized_payload, if_generation_match=request.base_generation)
+    except PreconditionFailed:
+        current_generation = _blob_generation(blob)
+        return _result(
+            request,
+            status=ApplyBatchStatus.STALE_GENERATION,
+            remote_generation=current_generation,
+            applied_count=0,
+            message=(
+                f"Remote generation changed during apply: local={request.base_generation}, remote={current_generation}"
+            ),
+        )
+    except Exception as exc:  # pragma: no cover - defensive guard around remote execution
+        return _result(
+            request,
+            status=ApplyBatchStatus.INTERNAL_ERROR,
+            remote_generation=remote_generation,
+            applied_count=0,
+            message=str(exc),
+        )
+
+    worker = ensure_worker_running(request, status_callback=status_callback)
+    status = ApplyBatchStatus.APPLIED
+    message = f"Applied {request.action.value} to {applied_count} {request.store.value} rows."
+    if worker.status == WorkerDispatchStatus.DISPATCH_FAILED:
+        status = ApplyBatchStatus.APPLIED_WITH_WORKER_WARNING
+        message = f"{message} Worker dispatch warning: {worker.detail or 'unknown gh error'}"
+
+    return _result(
+        request,
+        status=status,
+        remote_generation=remote_generation,
+        applied_count=applied_count,
+        message=message,
+        worker=worker,
+    )
+
+
+def ensure_worker_running(
+    request: ApplyBatchRequest,
+    status_callback: StatusCallback | None = None,
+) -> WorkerDispatchResult:
+    workflow = worker_workflow_for_action(request.store, request.action)
+    _status(status_callback, f"Checking whether {workflow} is already running…")
+
+    try:
+        runs = _list_workflow_runs(workflow)
+    except AdminRemoteApplyError as exc:
+        return WorkerDispatchResult(workflow=workflow, status=WorkerDispatchStatus.DISPATCH_FAILED, detail=str(exc))
+
+    active_run = next((run for run in runs if run.get("status") != "completed"), None)
+    if active_run is not None:
+        detail = f"already running: {active_run.get('url') or active_run.get('databaseId') or workflow}"
+        _status(status_callback, f"{workflow} is already running.")
+        return WorkerDispatchResult(workflow=workflow, status=WorkerDispatchStatus.ALREADY_RUNNING, detail=detail)
+
+    _status(status_callback, f"Dispatching {workflow}…")
+    try:
+        _run_gh_command(["workflow", "run", workflow])
+    except AdminRemoteApplyError as exc:
+        return WorkerDispatchResult(workflow=workflow, status=WorkerDispatchStatus.DISPATCH_FAILED, detail=str(exc))
+
+    return WorkerDispatchResult(workflow=workflow, status=WorkerDispatchStatus.DISPATCHED, detail="dispatched")
+
+
+def write_apply_result(result_path: Path, result: ApplyBatchResult) -> None:
+    result_path.parent.mkdir(parents=True, exist_ok=True)
+    result_path.write_text(result.to_json() + "\n")
+
+
+def append_apply_summary(summary_path: Path | None, result: ApplyBatchResult) -> None:
+    if summary_path is None:
+        return
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        f"# Admin apply: {result.status.value}",
+        "",
+        f"- store: `{result.store.value}`",
+        f"- action: `{result.action.value}`",
+        f"- snapshot: `{result.snapshot_id}`",
+        f"- base generation: `{result.base_generation}`",
+        f"- remote generation: `{result.remote_generation}`",
+        f"- applied count: `{result.applied_count}`",
+        f"- reason: {result.reason}",
+        f"- message: {result.message}",
+    ]
+    if result.worker is not None:
+        lines.extend(
+            [
+                f"- worker workflow: `{result.worker.workflow}`",
+                f"- worker status: `{result.worker.status.value}`",
+                f"- worker detail: {result.worker.detail or '—'}",
+            ]
+        )
+    summary_path.write_text("\n".join(lines) + "\n")
+
+
+def _bucket_for_storage(storage: str) -> Bucket:
+    uri = parse_gcs_url(storage)
+    if uri is None or uri.hostname is None:
+        raise AdminRemoteApplyError("Unsupported or invalid GCS storage URI")
+    client = Client(project=uri.username)
+    return client.bucket(uri.hostname)
+
+
+def _meta_blob_name(store: AdminStore) -> str:
+    if store == AdminStore.IPSW:
+        return IPSW_META_JSON
+    return OTA_META_JSON
+
+
+def _blob_generation(blob: Blob) -> int:
+    blob.reload()
+    generation = blob.generation
+    if generation is None:
+        return 0
+    return int(generation)
+
+
+def _load_ipsw_db(blob: Blob) -> IpswArtifactDb:
+    payload = str(cast(Any, blob).download_as_text())
+    return IpswArtifactDb.model_validate_json(payload)
+
+
+def _load_ota_meta(blob: Blob) -> dict[str, OtaArtifact]:
+    payload = str(cast(Any, blob).download_as_text())
+    raw_payload: object = json.loads(payload)
+    if not isinstance(raw_payload, dict):
+        raise AdminRemoteApplyError("Unexpected OTA meta-data payload")
+
+    payload = cast(dict[object, object], raw_payload)
+    result: dict[str, OtaArtifact] = {}
+    for key, value in payload.items():
+        if not isinstance(key, str):
+            raise AdminRemoteApplyError("Unexpected OTA meta-data key type")
+        if not isinstance(value, dict):
+            raise AdminRemoteApplyError("Unexpected OTA meta-data value type")
+        result[key] = OtaArtifact(**cast(dict[str, Any], value))
+    return result
+
+
+def _list_workflow_runs(workflow: str, limit: int = 10) -> list[dict[str, object]]:
+    result = _run_gh_command(
+        [
+            "run",
+            "list",
+            "--workflow",
+            workflow,
+            "--limit",
+            str(limit),
+            "--json",
+            "databaseId,status,url",
+        ]
+    )
+    raw_payload: object = json.loads(result.stdout)
+    if not isinstance(raw_payload, list):
+        raise AdminRemoteApplyError(f"Unexpected workflow run payload for {workflow}")
+    return cast(list[dict[str, object]], raw_payload)
+
+
+def _run_gh_command(args: list[str]) -> subprocess.CompletedProcess[str]:
+    cmd = ["gh", *args]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        stderr = result.stderr.strip() or result.stdout.strip() or "unknown gh error"
+        raise AdminRemoteApplyError(f"gh command failed: {' '.join(cmd)}\n{stderr}")
+    return result
+
+
+def _result(
+    request: ApplyBatchRequest,
+    *,
+    status: ApplyBatchStatus,
+    remote_generation: int,
+    applied_count: int,
+    message: str,
+    worker: WorkerDispatchResult | None = None,
+) -> ApplyBatchResult:
+    return ApplyBatchResult(
+        status=status,
+        store=request.store,
+        action=request.action,
+        snapshot_id=request.snapshot_id,
+        base_generation=request.base_generation,
+        remote_generation=remote_generation,
+        targets=request.targets,
+        reason=request.reason,
+        applied_count=applied_count,
+        message=message,
+        worker=worker,
+    )
+
+
+def _status(status_callback: StatusCallback | None, message: str) -> None:
+    if status_callback is not None:
+        status_callback(message)

--- a/symx/admin/remote.py
+++ b/symx/admin/remote.py
@@ -206,14 +206,14 @@ def _load_ipsw_db(blob: Blob) -> IpswArtifactDb:
 
 
 def _load_ota_meta(blob: Blob) -> dict[str, OtaArtifact]:
-    payload = str(cast(Any, blob).download_as_text())
-    raw_payload: object = json.loads(payload)
+    raw_json = str(cast(Any, blob).download_as_text())
+    raw_payload: object = json.loads(raw_json)
     if not isinstance(raw_payload, dict):
         raise AdminRemoteApplyError("Unexpected OTA meta-data payload")
 
-    payload = cast(dict[object, object], raw_payload)
+    ota_payload = cast(dict[object, object], raw_payload)
     result: dict[str, OtaArtifact] = {}
-    for key, value in payload.items():
+    for key, value in ota_payload.items():
         if not isinstance(key, str):
             raise AdminRemoteApplyError("Unexpected OTA meta-data key type")
         if not isinstance(value, dict):

--- a/symx/admin/sync.py
+++ b/symx/admin/sync.py
@@ -1,0 +1,383 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any, TypedDict, cast
+
+from symx.admin.db import (
+    SnapshotManifest,
+    SnapshotInfo,
+    SnapshotPaths,
+    active_snapshot_paths,
+    build_snapshot_db,
+    load_snapshot_info,
+    make_snapshot_id,
+    prepare_snapshot_dir,
+    snapshot_paths,
+    write_manifest,
+)
+from symx.ipsw.model import IpswArtifactDb
+from symx.ota.model import OtaArtifact
+
+ADMIN_META_WORKFLOW = "symx-admin-meta-sync.yml"
+ADMIN_META_ARTIFACT = "symx-admin-meta"
+ADMIN_META_SUMMARY = "admin_meta_summary.json"
+
+
+class AdminSyncError(RuntimeError):
+    pass
+
+
+class WorkflowRun(TypedDict):
+    databaseId: int
+    status: str
+    conclusion: str | None
+    url: str
+    startedAt: str | None
+    updatedAt: str | None
+    displayTitle: str
+    event: str
+
+
+class WorkflowArtifact(TypedDict, total=False):
+    name: str
+
+
+class WorkflowArtifactList(TypedDict):
+    artifacts: list[WorkflowArtifact]
+
+
+@dataclass(frozen=True)
+class WorkflowArtifactSummary:
+    ipsw_generation: int
+    ota_generation: int
+    ipsw_changed: bool
+    ota_changed: bool
+
+
+@dataclass(frozen=True)
+class DownloadedMetaBundle:
+    ipsw_db: IpswArtifactDb
+    ipsw_generation: int
+    ota_meta: dict[str, OtaArtifact]
+    ota_generation: int
+    ipsw_meta_path: Path
+    ota_meta_path: Path
+    ipsw_blob_path: Path
+    ota_blob_path: Path
+
+
+@dataclass(frozen=True)
+class SyncResult:
+    snapshot_id: str
+    workflow_run_id: int
+    workflow_run_url: str
+    ipsw_generation: int
+    ota_generation: int
+    is_new_snapshot: bool
+
+
+StatusCallback = Callable[[str], None]
+
+
+def run_sync(cache_dir: Path, status_callback: StatusCallback | None = None) -> SyncResult:
+    latest_paths, latest_info = _latest_cached_snapshot(cache_dir)
+
+    _status(status_callback, f"Checking existing workflow runs for {ADMIN_META_WORKFLOW}…")
+    before_max_run_id = _max_run_id(_list_workflow_runs(ADMIN_META_WORKFLOW, limit=10))
+
+    _status(status_callback, f"Dispatching {ADMIN_META_WORKFLOW}…")
+    _run_gh_command(_workflow_dispatch_args(latest_info))
+
+    _status(status_callback, "Waiting for the new workflow run to appear…")
+    run = _wait_for_new_run(ADMIN_META_WORKFLOW, before_max_run_id)
+    run_id = int(run["databaseId"])
+    run_url = str(run["url"])
+    _status(status_callback, f"Workflow run started: #{run_id}")
+
+    completed_run = _wait_for_run_completion(ADMIN_META_WORKFLOW, run_id, status_callback)
+    conclusion = completed_run.get("conclusion")
+    if conclusion != "success":
+        raise AdminSyncError(f"Admin sync workflow failed ({conclusion or 'unknown'}): {run_url}")
+
+    if not _run_has_artifact(run_id, ADMIN_META_ARTIFACT):
+        if latest_info is None:
+            raise AdminSyncError("Workflow reported no changes, but there is no local snapshot to keep using")
+        _status(status_callback, "Remote meta-data generations are unchanged. No download was needed.")
+        write_manifest(cache_dir, SnapshotManifest(active_snapshot_id=latest_info.snapshot_id))
+        return SyncResult(
+            snapshot_id=latest_info.snapshot_id,
+            workflow_run_id=run_id,
+            workflow_run_url=run_url,
+            ipsw_generation=latest_info.ipsw_generation,
+            ota_generation=latest_info.ota_generation,
+            is_new_snapshot=False,
+        )
+
+    with TemporaryDirectory(prefix="symx_admin_meta_") as temp_dir:
+        download_dir = Path(temp_dir)
+        _status(status_callback, f"Downloading workflow artifact to {download_dir}…")
+        _run_gh_command(["run", "download", str(run_id), "--name", ADMIN_META_ARTIFACT, "--dir", str(download_dir)])
+
+        _status(status_callback, "Parsing downloaded meta-data…")
+        bundle = _load_downloaded_bundle(download_dir, latest_paths)
+        snapshot_id = make_snapshot_id(bundle.ipsw_generation, bundle.ota_generation)
+        paths = snapshot_paths(cache_dir, snapshot_id)
+        is_new_snapshot = not _snapshot_is_ready(paths)
+
+        if is_new_snapshot:
+            _status(status_callback, f"Building snapshot {snapshot_id}…")
+            prepare_snapshot_dir(paths)
+            try:
+                shutil.copy2(bundle.ipsw_meta_path, paths.ipsw_meta_path)
+                shutil.copy2(bundle.ota_meta_path, paths.ota_meta_path)
+                shutil.copy2(bundle.ipsw_blob_path, paths.ipsw_blob_path)
+                shutil.copy2(bundle.ota_blob_path, paths.ota_blob_path)
+                build_snapshot_db(
+                    paths.db_path,
+                    snapshot_id,
+                    bundle.ipsw_db,
+                    bundle.ipsw_generation,
+                    bundle.ota_meta,
+                    bundle.ota_generation,
+                    workflow_run_id=run_id,
+                    workflow_run_url=run_url,
+                )
+            except Exception:
+                shutil.rmtree(paths.root, ignore_errors=True)
+                raise
+        else:
+            _status(status_callback, f"Snapshot {snapshot_id} already exists locally.")
+
+    write_manifest(cache_dir, SnapshotManifest(active_snapshot_id=snapshot_id))
+    _status(status_callback, f"Latest snapshot is now {snapshot_id}.")
+
+    return SyncResult(
+        snapshot_id=snapshot_id,
+        workflow_run_id=run_id,
+        workflow_run_url=run_url,
+        ipsw_generation=bundle.ipsw_generation,
+        ota_generation=bundle.ota_generation,
+        is_new_snapshot=is_new_snapshot,
+    )
+
+
+def _workflow_dispatch_args(latest_info: SnapshotInfo | None) -> list[str]:
+    args = ["workflow", "run", ADMIN_META_WORKFLOW]
+    if latest_info is None:
+        return args
+
+    args.extend(
+        [
+            "-f",
+            f"known_ipsw_generation={latest_info.ipsw_generation}",
+            "-f",
+            f"known_ota_generation={latest_info.ota_generation}",
+        ]
+    )
+    return args
+
+
+def _latest_cached_snapshot(cache_dir: Path) -> tuple[SnapshotPaths | None, SnapshotInfo | None]:
+    latest_paths = active_snapshot_paths(cache_dir)
+    if latest_paths is None:
+        return None, None
+    return latest_paths, load_snapshot_info(latest_paths.db_path)
+
+
+def _status(status_callback: StatusCallback | None, message: str) -> None:
+    if status_callback is not None:
+        status_callback(message)
+
+
+def _wait_for_new_run(workflow: str, before_max_run_id: int) -> WorkflowRun:
+    deadline = time.monotonic() + 120.0
+    while time.monotonic() < deadline:
+        runs = _list_workflow_runs(workflow, limit=10)
+        new_runs = [run for run in runs if int(run["databaseId"]) > before_max_run_id]
+        if new_runs:
+            return max(new_runs, key=lambda run: int(run["databaseId"]))
+        time.sleep(2.0)
+
+    raise AdminSyncError(f"Timed out waiting for a new workflow run for {workflow}")
+
+
+def _wait_for_run_completion(
+    workflow: str,
+    run_id: int,
+    status_callback: StatusCallback | None,
+) -> WorkflowRun:
+    deadline = time.monotonic() + 3600.0
+    last_status: tuple[str, str | None] | None = None
+
+    while time.monotonic() < deadline:
+        runs = _list_workflow_runs(workflow, limit=20)
+        matching_run = next((run for run in runs if int(run["databaseId"]) == run_id), None)
+        if matching_run is None:
+            time.sleep(5.0)
+            continue
+
+        status = str(matching_run["status"])
+        conclusion = matching_run["conclusion"]
+        current_status = (status, conclusion)
+        if current_status != last_status:
+            if status == "completed":
+                _status(status_callback, f"Workflow #{run_id} completed with conclusion={conclusion}")
+            else:
+                _status(status_callback, f"Workflow #{run_id} status={status}")
+            last_status = current_status
+
+        if status == "completed":
+            return matching_run
+
+        time.sleep(5.0)
+
+    raise AdminSyncError(f"Timed out waiting for workflow run #{run_id} to complete")
+
+
+def _list_workflow_runs(workflow: str, limit: int) -> list[WorkflowRun]:
+    result = _run_gh_command(
+        [
+            "run",
+            "list",
+            "--workflow",
+            workflow,
+            "--limit",
+            str(limit),
+            "--json",
+            "databaseId,status,conclusion,url,startedAt,updatedAt,displayTitle,event",
+        ]
+    )
+    data = json.loads(result.stdout)
+    if not isinstance(data, list):
+        raise AdminSyncError(f"Unexpected workflow run payload for {workflow}")
+    return cast(list[WorkflowRun], data)
+
+
+def _max_run_id(runs: list[WorkflowRun]) -> int:
+    if not runs:
+        return 0
+    return max(int(run["databaseId"]) for run in runs)
+
+
+def _run_has_artifact(run_id: int, artifact_name: str) -> bool:
+    result = _run_gh_command(["api", f"repos/{{owner}}/{{repo}}/actions/runs/{run_id}/artifacts"])
+    raw_payload: object = json.loads(result.stdout)
+    if not isinstance(raw_payload, dict):
+        raise AdminSyncError(f"Unexpected artifact payload for run #{run_id}")
+
+    payload = cast(WorkflowArtifactList, raw_payload)
+    return any(artifact.get("name") == artifact_name for artifact in payload.get("artifacts", []))
+
+
+def _run_gh_command(args: list[str]) -> subprocess.CompletedProcess[str]:
+    cmd = ["gh", *args]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        stderr = result.stderr.strip() or result.stdout.strip() or "unknown gh error"
+        raise AdminSyncError(f"gh command failed: {' '.join(cmd)}\n{stderr}")
+    return result
+
+
+def _load_downloaded_bundle(download_dir: Path, latest_paths: SnapshotPaths | None) -> DownloadedMetaBundle:
+    summary = _load_summary(download_dir)
+    ipsw_blob_path = _find_single_file(download_dir, "ipsw_meta_blob.json")
+    ota_blob_path = _find_single_file(download_dir, "ota_image_meta_blob.json")
+
+    if summary.ipsw_changed:
+        ipsw_meta_path = _find_single_file(download_dir, "ipsw_meta.json")
+    else:
+        if latest_paths is None:
+            raise AdminSyncError("Workflow returned only OTA changes, but there is no cached IPSW snapshot")
+        ipsw_meta_path = latest_paths.ipsw_meta_path
+
+    if summary.ota_changed:
+        ota_meta_path = _find_single_file(download_dir, "ota_image_meta.json")
+    else:
+        if latest_paths is None:
+            raise AdminSyncError("Workflow returned only IPSW changes, but there is no cached OTA snapshot")
+        ota_meta_path = latest_paths.ota_meta_path
+
+    return DownloadedMetaBundle(
+        ipsw_db=_load_ipsw_db(ipsw_meta_path),
+        ipsw_generation=summary.ipsw_generation,
+        ota_meta=_load_ota_meta(ota_meta_path),
+        ota_generation=summary.ota_generation,
+        ipsw_meta_path=ipsw_meta_path,
+        ota_meta_path=ota_meta_path,
+        ipsw_blob_path=ipsw_blob_path,
+        ota_blob_path=ota_blob_path,
+    )
+
+
+def _load_summary(download_dir: Path) -> WorkflowArtifactSummary:
+    summary_path = _find_single_file(download_dir, ADMIN_META_SUMMARY)
+    raw_payload: object = json.loads(summary_path.read_text())
+    if not isinstance(raw_payload, dict):
+        raise AdminSyncError("Unexpected admin meta summary payload")
+
+    payload = cast(dict[object, object], raw_payload)
+    return WorkflowArtifactSummary(
+        ipsw_generation=_coerce_int(payload.get("ipsw_generation"), summary_path, "ipsw_generation"),
+        ota_generation=_coerce_int(payload.get("ota_generation"), summary_path, "ota_generation"),
+        ipsw_changed=_coerce_bool(payload.get("ipsw_changed"), summary_path, "ipsw_changed"),
+        ota_changed=_coerce_bool(payload.get("ota_changed"), summary_path, "ota_changed"),
+    )
+
+
+def _load_ipsw_db(ipsw_meta_path: Path) -> IpswArtifactDb:
+    return IpswArtifactDb.model_validate_json(ipsw_meta_path.read_text())
+
+
+def _load_ota_meta(ota_meta_path: Path) -> dict[str, OtaArtifact]:
+    raw_ota_payload: object = json.loads(ota_meta_path.read_text())
+    if not isinstance(raw_ota_payload, dict):
+        raise AdminSyncError("Unexpected OTA meta-data payload")
+
+    ota_payload = cast(dict[object, object], raw_ota_payload)
+    ota_meta: dict[str, OtaArtifact] = {}
+    for key, value in ota_payload.items():
+        if not isinstance(key, str):
+            raise AdminSyncError("Unexpected OTA meta-data key type")
+        if not isinstance(value, dict):
+            raise AdminSyncError("Unexpected OTA meta-data value type")
+        ota_meta[key] = OtaArtifact(**cast(dict[str, Any], value))
+    return ota_meta
+
+
+def _snapshot_is_ready(paths: SnapshotPaths) -> bool:
+    required_paths = (
+        paths.db_path,
+        paths.ipsw_meta_path,
+        paths.ota_meta_path,
+        paths.ipsw_blob_path,
+        paths.ota_blob_path,
+    )
+    if not all(path.exists() for path in required_paths):
+        return False
+    return load_snapshot_info(paths.db_path) is not None
+
+
+def _find_single_file(root: Path, file_name: str) -> Path:
+    matches = list(root.rglob(file_name))
+    if len(matches) != 1:
+        raise AdminSyncError(f"Expected exactly one {file_name} in {root}, found {len(matches)}")
+    return matches[0]
+
+
+def _coerce_int(value: object, source: Path, field_name: str) -> int:
+    if not isinstance(value, (int, str)):
+        raise AdminSyncError(f"Unexpected {field_name} type in {source}")
+    return int(value)
+
+
+def _coerce_bool(value: object, source: Path, field_name: str) -> bool:
+    if not isinstance(value, bool):
+        raise AdminSyncError(f"Unexpected {field_name} type in {source}")
+    return value

--- a/symx/admin/sync.py
+++ b/symx/admin/sync.py
@@ -3,12 +3,10 @@ from __future__ import annotations
 import json
 import shutil
 import subprocess
-import time
-from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any, TypedDict, cast
+from typing import Any, cast
 
 from symx.admin.db import (
     SnapshotManifest,
@@ -22,6 +20,8 @@ from symx.admin.db import (
     snapshot_paths,
     write_manifest,
 )
+from symx.admin.gh_workflows import StatusCallback, WorkflowRun
+from symx.admin import gh_workflows
 from symx.ipsw.model import IpswArtifactDb
 from symx.ota.model import OtaArtifact
 
@@ -32,25 +32,6 @@ ADMIN_META_SUMMARY = "admin_meta_summary.json"
 
 class AdminSyncError(RuntimeError):
     pass
-
-
-class WorkflowRun(TypedDict):
-    databaseId: int
-    status: str
-    conclusion: str | None
-    url: str
-    startedAt: str | None
-    updatedAt: str | None
-    displayTitle: str
-    event: str
-
-
-class WorkflowArtifact(TypedDict, total=False):
-    name: str
-
-
-class WorkflowArtifactList(TypedDict):
-    artifacts: list[WorkflowArtifact]
 
 
 @dataclass(frozen=True)
@@ -81,9 +62,6 @@ class SyncResult:
     ipsw_generation: int
     ota_generation: int
     is_new_snapshot: bool
-
-
-StatusCallback = Callable[[str], None]
 
 
 def run_sync(cache_dir: Path, status_callback: StatusCallback | None = None) -> SyncResult:
@@ -192,20 +170,11 @@ def _latest_cached_snapshot(cache_dir: Path) -> tuple[SnapshotPaths | None, Snap
 
 
 def _status(status_callback: StatusCallback | None, message: str) -> None:
-    if status_callback is not None:
-        status_callback(message)
+    gh_workflows.emit_status(status_callback, message)
 
 
 def _wait_for_new_run(workflow: str, before_max_run_id: int) -> WorkflowRun:
-    deadline = time.monotonic() + 120.0
-    while time.monotonic() < deadline:
-        runs = _list_workflow_runs(workflow, limit=10)
-        new_runs = [run for run in runs if int(run["databaseId"]) > before_max_run_id]
-        if new_runs:
-            return max(new_runs, key=lambda run: int(run["databaseId"]))
-        time.sleep(2.0)
-
-    raise AdminSyncError(f"Timed out waiting for a new workflow run for {workflow}")
+    return gh_workflows.wait_for_new_run(workflow, before_max_run_id, AdminSyncError, _list_workflow_runs)
 
 
 def _wait_for_run_completion(
@@ -213,76 +182,23 @@ def _wait_for_run_completion(
     run_id: int,
     status_callback: StatusCallback | None,
 ) -> WorkflowRun:
-    deadline = time.monotonic() + 3600.0
-    last_status: tuple[str, str | None] | None = None
-
-    while time.monotonic() < deadline:
-        runs = _list_workflow_runs(workflow, limit=20)
-        matching_run = next((run for run in runs if int(run["databaseId"]) == run_id), None)
-        if matching_run is None:
-            time.sleep(5.0)
-            continue
-
-        status = str(matching_run["status"])
-        conclusion = matching_run["conclusion"]
-        current_status = (status, conclusion)
-        if current_status != last_status:
-            if status == "completed":
-                _status(status_callback, f"Workflow #{run_id} completed with conclusion={conclusion}")
-            else:
-                _status(status_callback, f"Workflow #{run_id} status={status}")
-            last_status = current_status
-
-        if status == "completed":
-            return matching_run
-
-        time.sleep(5.0)
-
-    raise AdminSyncError(f"Timed out waiting for workflow run #{run_id} to complete")
+    return gh_workflows.wait_for_run_completion(workflow, run_id, status_callback, AdminSyncError, _list_workflow_runs)
 
 
 def _list_workflow_runs(workflow: str, limit: int) -> list[WorkflowRun]:
-    result = _run_gh_command(
-        [
-            "run",
-            "list",
-            "--workflow",
-            workflow,
-            "--limit",
-            str(limit),
-            "--json",
-            "databaseId,status,conclusion,url,startedAt,updatedAt,displayTitle,event",
-        ]
-    )
-    data = json.loads(result.stdout)
-    if not isinstance(data, list):
-        raise AdminSyncError(f"Unexpected workflow run payload for {workflow}")
-    return cast(list[WorkflowRun], data)
+    return gh_workflows.list_workflow_runs(workflow, limit, AdminSyncError, _run_gh_command)
 
 
 def _max_run_id(runs: list[WorkflowRun]) -> int:
-    if not runs:
-        return 0
-    return max(int(run["databaseId"]) for run in runs)
+    return gh_workflows.max_run_id(runs)
 
 
 def _run_has_artifact(run_id: int, artifact_name: str) -> bool:
-    result = _run_gh_command(["api", f"repos/{{owner}}/{{repo}}/actions/runs/{run_id}/artifacts"])
-    raw_payload: object = json.loads(result.stdout)
-    if not isinstance(raw_payload, dict):
-        raise AdminSyncError(f"Unexpected artifact payload for run #{run_id}")
-
-    payload = cast(WorkflowArtifactList, raw_payload)
-    return any(artifact.get("name") == artifact_name for artifact in payload.get("artifacts", []))
+    return gh_workflows.run_has_artifact(run_id, artifact_name, AdminSyncError, _run_gh_command)
 
 
 def _run_gh_command(args: list[str]) -> subprocess.CompletedProcess[str]:
-    cmd = ["gh", *args]
-    result = subprocess.run(cmd, capture_output=True, text=True)
-    if result.returncode != 0:
-        stderr = result.stderr.strip() or result.stdout.strip() or "unknown gh error"
-        raise AdminSyncError(f"gh command failed: {' '.join(cmd)}\n{stderr}")
-    return result
+    return gh_workflows.run_gh_command(args, AdminSyncError)
 
 
 def _load_downloaded_bundle(download_dir: Path, latest_paths: SnapshotPaths | None) -> DownloadedMetaBundle:
@@ -365,10 +281,7 @@ def _snapshot_is_ready(paths: SnapshotPaths) -> bool:
 
 
 def _find_single_file(root: Path, file_name: str) -> Path:
-    matches = list(root.rglob(file_name))
-    if len(matches) != 1:
-        raise AdminSyncError(f"Expected exactly one {file_name} in {root}, found {len(matches)}")
-    return matches[0]
+    return gh_workflows.find_single_file(root, file_name, AdminSyncError)
 
 
 def _coerce_int(value: object, source: Path, field_name: str) -> int:

--- a/symx/admin/sync.py
+++ b/symx/admin/sync.py
@@ -274,7 +274,7 @@ def _find_single_file(root: Path, file_name: str) -> Path:
 
 
 def _coerce_int(value: object, source: Path, field_name: str) -> int:
-    if not isinstance(value, (int, str)):
+    if isinstance(value, bool) or not isinstance(value, (int, str)):
         raise AdminSyncError(f"Unexpected {field_name} type in {source}")
     return int(value)
 

--- a/symx/admin/sync.py
+++ b/symx/admin/sync.py
@@ -6,7 +6,7 @@ import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any, cast
+from typing import cast
 
 from symx.admin.db import (
     SnapshotManifest,
@@ -21,6 +21,7 @@ from symx.admin.db import (
     write_manifest,
 )
 from symx.admin.gh_workflows import StatusCallback, WorkflowRun
+from symx.admin.meta_json import parse_ota_meta_json
 from symx.admin import gh_workflows
 from symx.ipsw.model import IpswArtifactDb
 from symx.ota.model import OtaArtifact
@@ -252,19 +253,7 @@ def _load_ipsw_db(ipsw_meta_path: Path) -> IpswArtifactDb:
 
 
 def _load_ota_meta(ota_meta_path: Path) -> dict[str, OtaArtifact]:
-    raw_ota_payload: object = json.loads(ota_meta_path.read_text())
-    if not isinstance(raw_ota_payload, dict):
-        raise AdminSyncError("Unexpected OTA meta-data payload")
-
-    ota_payload = cast(dict[object, object], raw_ota_payload)
-    ota_meta: dict[str, OtaArtifact] = {}
-    for key, value in ota_payload.items():
-        if not isinstance(key, str):
-            raise AdminSyncError("Unexpected OTA meta-data key type")
-        if not isinstance(value, dict):
-            raise AdminSyncError("Unexpected OTA meta-data value type")
-        ota_meta[key] = OtaArtifact(**cast(dict[str, Any], value))
-    return ota_meta
+    return parse_ota_meta_json(ota_meta_path.read_text(), AdminSyncError)
 
 
 def _snapshot_is_ready(paths: SnapshotPaths) -> bool:

--- a/symx/admin/tui.py
+++ b/symx/admin/tui.py
@@ -1,0 +1,1170 @@
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime, timedelta
+from collections.abc import Callable
+from pathlib import Path
+from queue import Empty, Queue
+from typing import cast
+
+from rich.text import Text
+from textual.app import App, ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, DataTable, Footer, Header, Input, SelectionList, Static
+
+from symx.admin.actions import (
+    AdminActionKind,
+    AdminStore,
+    ApplyBatchResult,
+    ApplyBatchStatus,
+    IpswTarget,
+    OtaTarget,
+    PendingBatch,
+    action_label,
+    add_target_to_pending_batch,
+    batch_summary,
+    bind_pending_batch,
+    preview_action,
+    target_label,
+    with_pending_batch_reason,
+)
+from symx.admin.db import (
+    DEFAULT_FAILURE_STATES,
+    IpswSourceRow,
+    OtaArtifactRow,
+    SnapshotInfo,
+    active_snapshot_paths,
+    load_ipsw_rows,
+    load_ota_rows,
+    load_snapshot_info,
+    snapshot_paths,
+)
+from symx.admin.downloads import ArtifactDownloadResult, download_ipsw_to_cache, download_ota_to_cache
+from symx.admin.executor import AdminApplyError, run_apply
+from symx.admin.github import GithubRunInfo, ensure_github_run_infos, format_github_run_time, format_iso_timestamp
+from symx.admin.sync import AdminSyncError, SyncResult, run_sync
+from symx.model import ArtifactProcessingState
+
+EMPTY = "—"
+AUTO_SYNC_MAX_AGE = timedelta(hours=24)
+MAX_TASK_ROWS = 12
+
+
+class StateFilterScreen(ModalScreen[tuple[ArtifactProcessingState, ...] | None]):
+    CSS = """
+    StateFilterScreen {
+        align: center middle;
+        background: $background 70%;
+    }
+
+    #state-filter-dialog {
+        width: 72;
+        height: auto;
+        max-height: 28;
+        border: thick $primary;
+        background: $surface;
+        padding: 1 2;
+    }
+
+    #state-filter-buttons {
+        layout: horizontal;
+        align-horizontal: right;
+        padding-top: 1;
+        height: auto;
+    }
+
+    #state-filter-buttons Button {
+        margin-left: 1;
+    }
+
+    SelectionList {
+        height: 16;
+        margin-top: 1;
+    }
+    """
+
+    BINDINGS = [Binding("escape", "cancel", "Cancel")]
+
+    def __init__(self, selected_states: tuple[ArtifactProcessingState, ...]) -> None:
+        super().__init__()
+        self.selected_states = selected_states
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="state-filter-dialog"):
+            yield Static("Choose processing states to show", classes="section-title")
+            yield SelectionList[ArtifactProcessingState](
+                *[(state.value, state, state in self.selected_states) for state in ArtifactProcessingState],
+                id="state-filter-selection",
+            )
+            with Horizontal(id="state-filter-buttons"):
+                yield Button("Apply", id="apply")
+                yield Button("Defaults", id="defaults")
+                yield Button("Cancel", id="cancel")
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        button_id = event.button.id
+        if button_id == "cancel":
+            self.dismiss(None)
+            return
+        if button_id == "defaults":
+            self.dismiss(DEFAULT_FAILURE_STATES)
+            return
+        if button_id == "apply":
+            selection_list = cast(
+                SelectionList[ArtifactProcessingState], self.query_one("#state-filter-selection", SelectionList)
+            )
+            self.dismiss(tuple(selection_list.selected))
+
+
+class ReasonScreen(ModalScreen[str | None]):
+    CSS = """
+    ReasonScreen {
+        align: center middle;
+        background: $background 70%;
+    }
+
+    #reason-dialog {
+        width: 72;
+        height: auto;
+        border: thick $primary;
+        background: $surface;
+        padding: 1 2;
+    }
+
+    #reason-buttons {
+        layout: horizontal;
+        align-horizontal: right;
+        padding-top: 1;
+        height: auto;
+    }
+
+    #reason-buttons Button {
+        margin-left: 1;
+    }
+
+    #reason-input {
+        margin-top: 1;
+    }
+    """
+
+    BINDINGS = [Binding("escape", "cancel", "Cancel")]
+
+    def __init__(self, initial_reason: str = "") -> None:
+        super().__init__()
+        self.initial_reason = initial_reason
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="reason-dialog"):
+            yield Static("Provide a reason for this admin rerun batch", classes="section-title")
+            yield Input(value=self.initial_reason, placeholder="Reason", id="reason-input")
+            with Horizontal(id="reason-buttons"):
+                yield Button("Apply", id="apply")
+                yield Button("Cancel", id="cancel")
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "cancel":
+            self.dismiss(None)
+            return
+        if event.button.id == "apply":
+            reason = self.query_one("#reason-input", Input).value.strip()
+            if reason:
+                self.dismiss(reason)
+
+
+@dataclass(frozen=True)
+class BackgroundTaskEntry:
+    task_id: str
+    kind: str
+    status: str
+    item: str
+    progress_detail: str
+    result_detail: str | None = None
+
+
+@dataclass(frozen=True)
+class DownloadQueueItem:
+    task_id: str
+    item_label: str
+    row: IpswSourceRow | OtaArtifactRow
+
+
+class AdminTui(App[None]):
+    CSS = """
+    Screen {
+        layout: vertical;
+    }
+
+    #status {
+        height: 3;
+        padding: 0 1;
+        background: $panel;
+        color: $text;
+    }
+
+    #body {
+        height: 1fr;
+        layout: horizontal;
+    }
+
+    #tables {
+        width: 2fr;
+        height: 1fr;
+        layout: vertical;
+    }
+
+    #details-pane {
+        width: 1fr;
+        min-width: 42;
+        height: 1fr;
+        border-left: solid $primary;
+        layout: vertical;
+    }
+
+    #details {
+        height: 1fr;
+        padding: 0 1;
+    }
+
+    #pending-batch {
+        height: 12;
+        padding: 0 1;
+    }
+
+    #tasks {
+        height: 12;
+    }
+
+    .section-title {
+        padding: 0 1;
+        text-style: bold;
+    }
+
+    DataTable {
+        height: 1fr;
+    }
+    """
+
+    BINDINGS = [
+        Binding("s", "sync", "Refresh"),
+        Binding("u", "use_latest", "Use latest"),
+        Binding("f", "edit_filters", "Filters"),
+        Binding("d", "download_selected", "Download"),
+        Binding("e", "queue_extract_selected", "Queue extract"),
+        Binding("m", "queue_mirror_selected", "Queue mirror"),
+        Binding("a", "apply_batch", "Apply batch"),
+        Binding("c", "clear_batch", "Clear batch"),
+        Binding("q", "quit", "Quit"),
+    ]
+
+    def __init__(
+        self, cache_dir: Path, failure_states: tuple[ArtifactProcessingState, ...] = DEFAULT_FAILURE_STATES
+    ) -> None:
+        super().__init__()
+        self.cache_dir = cache_dir
+        self.failure_states = failure_states
+        self._sync_lock = threading.Lock()
+        self._sync_thread: threading.Thread | None = None
+        self._sync_activate_latest = False
+        self._apply_thread: threading.Thread | None = None
+        self._download_worker_thread: threading.Thread | None = None
+        self._run_lookup_thread: threading.Thread | None = None
+        self._download_queue: Queue[DownloadQueueItem] = Queue()
+        self.current_snapshot_id: str | None = None
+        self.pending_snapshot_id: str | None = None
+        self._current_snapshot_info: SnapshotInfo | None = None
+        self._run_infos: dict[int, GithubRunInfo] = ensure_github_run_infos(cache_dir, [])
+        self._ipsw_rows: list[IpswSourceRow] = []
+        self._ipsw_rows_by_key: dict[str, IpswSourceRow] = {}
+        self._all_ipsw_rows_by_key: dict[str, IpswSourceRow] = {}
+        self._selected_ipsw_row_key: str | None = None
+        self._ota_rows: list[OtaArtifactRow] = []
+        self._ota_rows_by_key: dict[str, OtaArtifactRow] = {}
+        self._all_ota_rows_by_key: dict[str, OtaArtifactRow] = {}
+        self._selected_ota_row_key: str | None = None
+        self._active_table_id: str | None = None
+        self._selected_task_id: str | None = None
+        self._pending_batch: PendingBatch | None = None
+        self._task_counter = 0
+        self._task_order: list[str] = []
+        self._tasks: dict[str, BackgroundTaskEntry] = {}
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        yield Static(self._status_text("Opening admin cache…"), id="status")
+        with Horizontal(id="body"):
+            with Vertical(id="tables"):
+                yield Static(format_failure_table_title("IPSW sources", 0), classes="section-title", id="ipsw-title")
+                yield DataTable[str](id="ipsw-failures", cursor_type="row")
+                yield Static(format_failure_table_title("OTA artifacts", 0), classes="section-title", id="ota-title")
+                yield DataTable[str](id="ota-failures", cursor_type="row")
+            with Vertical(id="details-pane"):
+                yield Static("Details", classes="section-title")
+                yield Static(self._detail_text(), id="details")
+                yield Static("Pending batch", classes="section-title")
+                yield Static(self._pending_batch_text(), id="pending-batch")
+                yield Static("Background tasks", classes="section-title")
+                yield DataTable[object](id="tasks", cursor_type="row")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self.title = "symx admin"
+        self._configure_tables()
+        self._refresh_task_table()
+        self._load_current_snapshot(initial=True)
+        if should_auto_sync_on_start(self._current_snapshot_info):
+            self._start_sync_thread()
+        elif self.current_snapshot_id is not None:
+            self._set_status(
+                f"Loaded cached snapshot {self.current_snapshot_id}. Auto sync skipped because it is less than 24h old."
+            )
+
+    def action_sync(self) -> None:
+        self._start_sync_thread(manual=True)
+
+    def action_use_latest(self) -> None:
+        if self.pending_snapshot_id is None:
+            self._set_status("No newer snapshot available.")
+            return
+
+        self.current_snapshot_id = self.pending_snapshot_id
+        self.pending_snapshot_id = None
+        self._load_current_snapshot(initial=False)
+        self._set_status(f"Switched to snapshot {self.current_snapshot_id}.")
+
+    def action_edit_filters(self) -> None:
+        self.push_screen(StateFilterScreen(self.failure_states), self._on_filter_screen_dismissed)
+
+    def action_download_selected(self) -> None:
+        request = self._selected_download_request()
+        if request is None:
+            self._set_status("No row selected for download.")
+            return
+
+        task_id = self._create_task(kind="download", status="queued", item=request.item_label, detail="Queued")
+        self._download_queue.put(replace(request, task_id=task_id))
+        self._refresh_task_table()
+        self._set_status(f"Queued download for {request.item_label}.")
+        self._start_download_worker()
+
+    def action_queue_extract_selected(self) -> None:
+        self._queue_selected(AdminActionKind.QUEUE_EXTRACT)
+
+    def action_queue_mirror_selected(self) -> None:
+        self._queue_selected(AdminActionKind.QUEUE_MIRROR)
+
+    def action_apply_batch(self) -> None:
+        if self._pending_batch is None or not self._pending_batch.targets:
+            self._set_status("No pending batch to apply.")
+            return
+        if self._current_snapshot_info is None:
+            self._set_status("No snapshot is loaded yet.")
+            return
+        if self._pending_batch.reason.strip():
+            self._start_apply_thread(self._pending_batch)
+            return
+        self.push_screen(ReasonScreen(), self._on_reason_screen_dismissed)
+
+    def action_clear_batch(self) -> None:
+        if self._pending_batch is None:
+            self._set_status("No pending batch to clear.")
+            return
+        self._pending_batch = None
+        self._refresh_pending_batch()
+        self._set_status("Cleared pending batch.")
+
+    def on_data_table_row_highlighted(self, event: DataTable.RowHighlighted) -> None:
+        table_id = self.focused.id if self.focused is not None else None
+        row_key = event.row_key.value
+        if table_id not in {"ipsw-failures", "ota-failures", "tasks"} or row_key is None:
+            return
+
+        self._active_table_id = table_id
+        if table_id == "ipsw-failures":
+            self._selected_ipsw_row_key = row_key if row_key in self._ipsw_rows_by_key else None
+        elif table_id == "ota-failures":
+            self._selected_ota_row_key = row_key if row_key in self._ota_rows_by_key else None
+        elif table_id == "tasks":
+            self._selected_task_id = row_key if row_key in self._tasks else None
+        self._refresh_details()
+
+    def _configure_tables(self) -> None:
+        ipsw_table = cast(DataTable[str], self.query_one("#ipsw-failures", DataTable))
+        ipsw_table.add_columns("last_modified", "state", "platform", "version", "build", "file_name", "artifact_key")
+
+        ota_table = cast(DataTable[str], self.query_one("#ota-failures", DataTable))
+        ota_table.add_columns("last_run_at", "state", "platform", "version", "build", "artifact_id", "ota_key")
+
+        tasks_table = cast(DataTable[object], self.query_one("#tasks", DataTable))
+        tasks_table.add_columns("type", "status", "item", "detail")
+
+    def _load_current_snapshot(self, initial: bool) -> None:
+        if self.current_snapshot_id is None:
+            active_paths = active_snapshot_paths(self.cache_dir)
+            if active_paths is not None:
+                self.current_snapshot_id = active_paths.snapshot_id
+
+        if self.current_snapshot_id is None:
+            self._current_snapshot_info = None
+            self._all_ipsw_rows_by_key = {}
+            self._all_ota_rows_by_key = {}
+            self._populate_ipsw_table([])
+            self._populate_ota_table([])
+            self.sub_title = self._subtitle()
+            self._refresh_details()
+            self._refresh_pending_batch()
+            if initial:
+                self._set_status("No cached snapshot found. Starting background sync…")
+            return
+
+        db_path = snapshot_paths(self.cache_dir, self.current_snapshot_id).db_path
+        self._current_snapshot_info = load_snapshot_info(db_path)
+        all_ipsw_rows = load_ipsw_rows(db_path)
+        self._all_ipsw_rows_by_key = {_ipsw_row_key(row): row for row in all_ipsw_rows}
+        visible_ipsw_rows = [row for row in all_ipsw_rows if row.processing_state in self.failure_states]
+        self._populate_ipsw_table(visible_ipsw_rows)
+        all_ota_rows = load_ota_rows(db_path)
+        self._all_ota_rows_by_key = {_ota_row_key(row): row for row in all_ota_rows}
+        visible_ota_rows = [row for row in all_ota_rows if row.processing_state in self.failure_states]
+        self._populate_ota_table(visible_ota_rows)
+        self._start_run_lookup_thread(all_ota_rows)
+        self.sub_title = self._subtitle()
+        self._refresh_details()
+        self._refresh_pending_batch()
+        if initial:
+            self._set_status(f"Loaded cached snapshot {self.current_snapshot_id}.")
+
+    def _populate_ipsw_table(self, rows: list[IpswSourceRow]) -> None:
+        table = cast(DataTable[str], self.query_one("#ipsw-failures", DataTable))
+        previous_row_key = self._selected_ipsw_row_key
+        self._ipsw_rows = rows
+        self._ipsw_rows_by_key = {}
+        table.clear(columns=False)
+        self._set_failure_table_title("ipsw", len(rows))
+        if not rows:
+            self._selected_ipsw_row_key = None
+            table.add_row(EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, "No matching IPSW rows", EMPTY, key="empty-ipsw")
+            self._ensure_active_table()
+            return
+
+        for row in rows:
+            row_key = _ipsw_row_key(row)
+            self._ipsw_rows_by_key[row_key] = row
+            table.add_row(
+                row.last_modified or EMPTY,
+                row.processing_state.value,
+                row.platform,
+                row.version,
+                row.build,
+                row.file_name,
+                row.artifact_key,
+                key=row_key,
+            )
+
+        self._selected_ipsw_row_key = self._restore_row_selection(table, previous_row_key, list(self._ipsw_rows_by_key))
+        self._ensure_active_table()
+
+    def _populate_ota_table(self, rows: list[OtaArtifactRow]) -> None:
+        table = cast(DataTable[str], self.query_one("#ota-failures", DataTable))
+        previous_row_key = self._selected_ota_row_key
+        self._ota_rows = rows
+        self._ota_rows_by_key = {}
+        table.clear(columns=False)
+        self._set_failure_table_title("ota", len(rows))
+        if not rows:
+            self._selected_ota_row_key = None
+            table.add_row(EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, "No matching OTA rows", EMPTY, key="empty-ota")
+            self._ensure_active_table()
+            return
+
+        for row in rows:
+            row_key = _ota_row_key(row)
+            self._ota_rows_by_key[row_key] = row
+            table.add_row(
+                format_github_run_time(row.last_run, self._run_infos.get(row.last_run)),
+                row.processing_state.value,
+                row.platform,
+                row.version,
+                row.build,
+                row.artifact_id,
+                row.ota_key,
+                key=row_key,
+            )
+
+        self._selected_ota_row_key = self._restore_row_selection(table, previous_row_key, list(self._ota_rows_by_key))
+        self._ensure_active_table()
+
+    def _restore_row_selection(
+        self,
+        table: DataTable[str],
+        previous_row_key: str | None,
+        current_row_keys: list[str],
+    ) -> str | None:
+        if not current_row_keys:
+            return None
+
+        target_row_key = previous_row_key if previous_row_key in current_row_keys else current_row_keys[0]
+        table.move_cursor(row=table.get_row_index(target_row_key), animate=False, scroll=False)
+        return target_row_key
+
+    def _ensure_active_table(self) -> None:
+        if self._active_table_id == "ipsw-failures" and self._selected_ipsw_row_key is not None:
+            return
+        if self._active_table_id == "ota-failures" and self._selected_ota_row_key is not None:
+            return
+        if self._active_table_id == "tasks" and self._selected_task_id is not None:
+            return
+        if self._selected_ipsw_row_key is not None:
+            self._active_table_id = "ipsw-failures"
+            return
+        if self._selected_ota_row_key is not None:
+            self._active_table_id = "ota-failures"
+            return
+        if self._selected_task_id is not None:
+            self._active_table_id = "tasks"
+            return
+        self._active_table_id = None
+
+    def _set_failure_table_title(self, platform: str, count: int) -> None:
+        if platform == "ipsw":
+            self.query_one("#ipsw-title", Static).update(format_failure_table_title("IPSW sources", count))
+        elif platform == "ota":
+            self.query_one("#ota-title", Static).update(format_failure_table_title("OTA artifacts", count))
+
+    def _refresh_details(self) -> None:
+        self.query_one("#details", Static).update(self._detail_text())
+
+    def _refresh_pending_batch(self) -> None:
+        self.query_one("#pending-batch", Static).update(self._pending_batch_text())
+
+    def _pending_batch_text(self) -> str:
+        if self._pending_batch is None:
+            return batch_summary(None)
+
+        lines = [batch_summary(self._pending_batch), "", "Preview:"]
+        for target in self._pending_batch.targets[:8]:
+            preview_text = self._preview_target(target)
+            lines.append(f"  - {preview_text}")
+        if len(self._pending_batch.targets) > 8:
+            lines.append(f"  … and {len(self._pending_batch.targets) - 8} more")
+        return "\n".join(lines)
+
+    def _preview_target(self, target: IpswTarget | OtaTarget) -> str:
+        batch = self._pending_batch
+        if batch is None:
+            return target_label(target)
+
+        if isinstance(target, IpswTarget):
+            row = self._all_ipsw_rows_by_key.get(f"{target.artifact_key}::{target.link}")
+            if row is None:
+                return f"{target_label(target)} (missing from current snapshot)"
+            preview = preview_action(
+                AdminStore.IPSW,
+                batch.action,
+                row.processing_state,
+                has_required_path=row.mirror_path is not None,
+            )
+            if preview.resulting_state is None:
+                return f"{target_label(target)} ({preview.note})"
+            return f"{row.file_name}: {row.processing_state.value} -> {preview.resulting_state.value} ({preview.note})"
+
+        row = self._all_ota_rows_by_key.get(target.ota_key)
+        if row is None:
+            return f"{target_label(target)} (missing from current snapshot)"
+        preview = preview_action(
+            AdminStore.OTA,
+            batch.action,
+            row.processing_state,
+            has_required_path=row.download_path is not None,
+        )
+        if preview.resulting_state is None:
+            return f"{target_label(target)} ({preview.note})"
+        return f"{row.artifact_id}: {row.processing_state.value} -> {preview.resulting_state.value} ({preview.note})"
+
+    def _detail_text(self) -> str:
+        if self._active_table_id == "tasks" and self._selected_task_id is not None:
+            task = self._tasks.get(self._selected_task_id)
+            if task is not None:
+                return format_task_detail(task)
+
+        if self._active_table_id == "ota-failures" and self._selected_ota_row_key is not None:
+            row = self._ota_rows_by_key.get(self._selected_ota_row_key)
+            if row is not None:
+                return format_ota_detail(row, self._run_infos.get(row.last_run))
+
+        if self._active_table_id == "ipsw-failures" and self._selected_ipsw_row_key is not None:
+            row = self._ipsw_rows_by_key.get(self._selected_ipsw_row_key)
+            if row is not None:
+                return format_ipsw_detail(row)
+
+        if self._selected_ipsw_row_key is not None:
+            row = self._ipsw_rows_by_key.get(self._selected_ipsw_row_key)
+            if row is not None:
+                return format_ipsw_detail(row)
+
+        if self._selected_ota_row_key is not None:
+            row = self._ota_rows_by_key.get(self._selected_ota_row_key)
+            if row is not None:
+                return format_ota_detail(row, self._run_infos.get(row.last_run))
+
+        if self._selected_task_id is not None:
+            task = self._tasks.get(self._selected_task_id)
+            if task is not None:
+                return format_task_detail(task)
+
+        return "No row selected. Use arrow keys to move in a table, then press 'd' to queue a download."
+
+    def _selected_download_request(self) -> DownloadQueueItem | None:
+        if self._active_table_id == "ipsw-failures" and self._selected_ipsw_row_key is not None:
+            row = self._ipsw_rows_by_key.get(self._selected_ipsw_row_key)
+            if row is not None:
+                return DownloadQueueItem(task_id="", item_label=row.file_name, row=row)
+
+        if self._active_table_id == "ota-failures" and self._selected_ota_row_key is not None:
+            row = self._ota_rows_by_key.get(self._selected_ota_row_key)
+            if row is not None:
+                return DownloadQueueItem(task_id="", item_label=row.artifact_id, row=row)
+
+        return None
+
+    def _selected_batch_target(self) -> tuple[AdminStore, IpswTarget | OtaTarget] | None:
+        if self._active_table_id == "ipsw-failures" and self._selected_ipsw_row_key is not None:
+            row = self._ipsw_rows_by_key.get(self._selected_ipsw_row_key)
+            if row is not None:
+                return AdminStore.IPSW, IpswTarget(artifact_key=row.artifact_key, link=row.link)
+
+        if self._active_table_id == "ota-failures" and self._selected_ota_row_key is not None:
+            row = self._ota_rows_by_key.get(self._selected_ota_row_key)
+            if row is not None:
+                return AdminStore.OTA, OtaTarget(ota_key=row.ota_key)
+
+        return None
+
+    def _queue_selected(self, action: AdminActionKind) -> None:
+        selected = self._selected_batch_target()
+        if selected is None:
+            self._set_status("No row selected to add to the pending batch.")
+            return
+
+        store, target = selected
+        if self._pending_batch is None:
+            self._pending_batch = PendingBatch(store=store, action=action, targets=(target,))
+        else:
+            if self._pending_batch.store != store or self._pending_batch.action != action:
+                self._set_status("Pending batch already targets a different store or action. Clear it first.")
+                return
+            previous_count = len(self._pending_batch.targets)
+            self._pending_batch = add_target_to_pending_batch(self._pending_batch, target)
+            if len(self._pending_batch.targets) == previous_count:
+                self._set_status(f"{target_label(target)} is already in the pending batch.")
+                return
+
+        self._refresh_pending_batch()
+        self._set_status(f"Added {target_label(target)} to {action_label(action).lower()} batch.")
+
+    def _start_sync_thread(self, manual: bool = False, activate_latest: bool = False) -> None:
+        if self._sync_thread is not None and self._sync_thread.is_alive():
+            if manual:
+                self._set_status("Sync already running…")
+            if activate_latest:
+                self._sync_activate_latest = True
+            return
+
+        if activate_latest:
+            self._sync_activate_latest = True
+
+        task_id = self._create_task(
+            kind="sync",
+            status="queued",
+            item="manual" if manual else "startup",
+            detail="Queued",
+        )
+        prefix = "Manual sync requested" if manual else "Starting background sync"
+        self._set_status(f"{prefix}…")
+        self._sync_thread = threading.Thread(target=self._run_sync, args=(task_id,), daemon=True)
+        self._sync_thread.start()
+
+    def _run_sync(self, task_id: str) -> None:
+        if not self._sync_lock.acquire(blocking=False):
+            return
+
+        self._task_update_from_thread(task_id, status="running", progress_detail="Running")
+        try:
+            result = run_sync(
+                self.cache_dir, status_callback=lambda message: self._sync_progress_from_thread(task_id, message)
+            )
+        except AdminSyncError as exc:
+            self._task_update_from_thread(task_id, status="failed", result_detail=str(exc))
+            self._status_from_thread(f"Sync failed: {exc}")
+            return
+        except Exception as exc:  # pragma: no cover - defensive UI guard
+            self._task_update_from_thread(task_id, status="failed", result_detail=str(exc))
+            self._status_from_thread(f"Unexpected sync failure: {exc}")
+            return
+        finally:
+            self._sync_lock.release()
+
+        self.call_from_thread(self._handle_sync_result, result, task_id)
+
+    def _sync_progress_from_thread(self, task_id: str, message: str) -> None:
+        self.call_from_thread(self._sync_progress, task_id, message)
+
+    def _sync_progress(self, task_id: str, message: str) -> None:
+        self._update_task(task_id, status="running", progress_detail=message)
+        self._set_status(message)
+
+    def _handle_sync_result(self, result: SyncResult, task_id: str) -> None:
+        activate_latest = self._sync_activate_latest
+        self._sync_activate_latest = False
+
+        if self.current_snapshot_id is None:
+            self.current_snapshot_id = result.snapshot_id
+            self.pending_snapshot_id = None
+            self._load_current_snapshot(initial=False)
+            self._update_task(task_id, status="done", result_detail="Initial snapshot loaded")
+            self._set_status(f"Initial snapshot {result.snapshot_id} loaded.")
+            return
+
+        if result.snapshot_id == self.current_snapshot_id:
+            self.pending_snapshot_id = None
+            self._update_task(task_id, status="done", result_detail="Already on the latest snapshot")
+            self._set_status(f"Already on latest snapshot {result.snapshot_id}.")
+            return
+
+        if activate_latest:
+            self.current_snapshot_id = result.snapshot_id
+            self.pending_snapshot_id = None
+            self._load_current_snapshot(initial=False)
+            self._update_task(task_id, status="done", result_detail=f"Loaded latest snapshot {result.snapshot_id}")
+            self._set_status(f"Loaded latest snapshot {result.snapshot_id}.")
+            return
+
+        self.pending_snapshot_id = result.snapshot_id
+        self.sub_title = self._subtitle()
+        self._update_task(task_id, status="done", result_detail=f"New snapshot {result.snapshot_id} is ready")
+        self._set_status(f"New snapshot {result.snapshot_id} is ready. Press 'u' to switch.")
+
+    def _start_apply_thread(self, batch: PendingBatch) -> None:
+        if self._apply_thread is not None and self._apply_thread.is_alive():
+            self._set_status("Apply already running…")
+            return
+
+        task_id = self._create_task(
+            kind="apply",
+            status="queued",
+            item=f"{batch.store.value}:{batch.action.value}",
+            detail=f"Queued ({len(batch.targets)} targets)",
+        )
+        self._set_status("Starting admin apply…")
+        self._apply_thread = threading.Thread(target=self._run_apply_batch, args=(batch, task_id), daemon=True)
+        self._apply_thread.start()
+
+    def _run_apply_batch(self, batch: PendingBatch, task_id: str) -> None:
+        snapshot_info = self._current_snapshot_info
+        if snapshot_info is None:
+            self._task_update_from_thread(task_id, status="failed", result_detail="No snapshot is loaded")
+            self._status_from_thread("Cannot apply without a loaded snapshot.")
+            return
+
+        try:
+            request = bind_pending_batch(batch, snapshot_info)
+        except ValueError as exc:
+            self._task_update_from_thread(task_id, status="failed", result_detail=str(exc))
+            self._status_from_thread(str(exc))
+            return
+
+        self._task_update_from_thread(task_id, status="running", progress_detail="Running")
+        try:
+            result = run_apply(
+                request, status_callback=lambda message: self._apply_progress_from_thread(task_id, message)
+            )
+        except AdminApplyError as exc:
+            self._task_update_from_thread(task_id, status="failed", result_detail=str(exc))
+            self._status_from_thread(f"Admin apply failed: {exc}")
+            return
+        except Exception as exc:  # pragma: no cover - defensive UI guard
+            self._task_update_from_thread(task_id, status="failed", result_detail=str(exc))
+            self._status_from_thread(f"Unexpected admin apply failure: {exc}")
+            return
+
+        self.call_from_thread(self._handle_apply_result, batch, result, task_id)
+
+    def _apply_progress_from_thread(self, task_id: str, message: str) -> None:
+        self.call_from_thread(self._apply_progress, task_id, message)
+
+    def _apply_progress(self, task_id: str, message: str) -> None:
+        self._update_task(task_id, status="running", progress_detail=message)
+        self._set_status(message)
+
+    def _handle_apply_result(self, batch: PendingBatch, result: ApplyBatchResult, task_id: str) -> None:
+        status = "done"
+        if result.status == ApplyBatchStatus.APPLIED_WITH_WORKER_WARNING:
+            status = "warning"
+        elif result.status in {
+            ApplyBatchStatus.STALE_GENERATION,
+            ApplyBatchStatus.VALIDATION_FAILED,
+            ApplyBatchStatus.INTERNAL_ERROR,
+        }:
+            status = "failed"
+
+        self._update_task(task_id, status=status, result_detail=result.message)
+        if result.status in {ApplyBatchStatus.APPLIED, ApplyBatchStatus.APPLIED_WITH_WORKER_WARNING}:
+            self._pending_batch = None
+            self._refresh_pending_batch()
+            self._set_status(result.message)
+            self._start_sync_thread(activate_latest=True)
+            return
+
+        self._pending_batch = batch
+        self._refresh_pending_batch()
+        if result.status == ApplyBatchStatus.STALE_GENERATION:
+            self._set_status(f"{result.message} Refreshing snapshot now…")
+            self._start_sync_thread(activate_latest=True)
+            return
+        self._set_status(result.message)
+
+    def _start_download_worker(self) -> None:
+        if self._download_worker_thread is not None and self._download_worker_thread.is_alive():
+            return
+
+        self._download_worker_thread = threading.Thread(target=self._run_download_worker, daemon=True)
+        self._download_worker_thread.start()
+
+    def _run_download_worker(self) -> None:
+        try:
+            while True:
+                try:
+                    item = self._download_queue.get(timeout=0.2)
+                except Empty:
+                    return
+
+                self._task_update_from_thread(item.task_id, status="running", progress_detail="Downloading")
+                self._status_from_thread(f"Downloading {item.item_label}…")
+                try:
+                    result = _download_selected_item(
+                        item.row,
+                        self.cache_dir,
+                        status_callback=lambda message: self._download_progress_from_thread(item.task_id, message),
+                    )
+                except Exception as exc:
+                    self._task_update_from_thread(item.task_id, status="failed", result_detail=str(exc))
+                    self._status_from_thread(f"Download failed for {item.item_label}: {exc}")
+                else:
+                    self._handle_download_result_from_thread(item, result)
+                finally:
+                    self._download_queue.task_done()
+        finally:
+            self._download_worker_thread = None
+
+    def _download_progress_from_thread(self, task_id: str, message: str) -> None:
+        self.call_from_thread(self._update_task, task_id, progress_detail=message)
+
+    def _handle_download_result_from_thread(self, item: DownloadQueueItem, result: ArtifactDownloadResult) -> None:
+        self.call_from_thread(self._handle_download_result, item, result)
+
+    def _handle_download_result(self, item: DownloadQueueItem, result: ArtifactDownloadResult) -> None:
+        task_status = "done" if result.verified else "warning"
+        self._update_task(item.task_id, status=task_status, result_detail=result.message)
+        if result.verified:
+            self._set_status(f"Download complete for {item.item_label}.")
+        else:
+            self._set_status(f"Download complete for {item.item_label} (unverified).")
+
+    def _start_run_lookup_thread(self, ota_rows: list[OtaArtifactRow]) -> None:
+        missing_run_ids = [row.last_run for row in ota_rows if row.last_run > 0 and row.last_run not in self._run_infos]
+        if not missing_run_ids:
+            return
+        if self._run_lookup_thread is not None and self._run_lookup_thread.is_alive():
+            return
+
+        self._run_lookup_thread = threading.Thread(
+            target=self._resolve_run_infos,
+            args=(tuple(dict.fromkeys(missing_run_ids)),),
+            daemon=True,
+        )
+        self._run_lookup_thread.start()
+
+    def _resolve_run_infos(self, run_ids: tuple[int, ...]) -> None:
+        try:
+            run_infos = ensure_github_run_infos(self.cache_dir, run_ids)
+        except Exception:  # pragma: no cover - best effort UI enhancement
+            return
+        self.call_from_thread(self._merge_run_infos, run_infos)
+
+    def _merge_run_infos(self, run_infos: dict[int, GithubRunInfo]) -> None:
+        self._run_infos.update(run_infos)
+        if self._ota_rows:
+            self._populate_ota_table(self._ota_rows)
+            self._refresh_details()
+
+    def _create_task(self, kind: str, status: str, item: str, detail: str) -> str:
+        self._task_counter += 1
+        task_id = f"task-{self._task_counter}"
+        self._task_order.append(task_id)
+        self._tasks[task_id] = BackgroundTaskEntry(
+            task_id=task_id,
+            kind=kind,
+            status=status,
+            item=item,
+            progress_detail=detail,
+        )
+        self._refresh_task_table()
+        return task_id
+
+    def _update_task(
+        self,
+        task_id: str,
+        *,
+        status: str | None = None,
+        progress_detail: str | None = None,
+        result_detail: str | None = None,
+    ) -> None:
+        task = self._tasks.get(task_id)
+        if task is None:
+            return
+
+        self._tasks[task_id] = BackgroundTaskEntry(
+            task_id=task.task_id,
+            kind=task.kind,
+            status=status or task.status,
+            item=task.item,
+            progress_detail=progress_detail or task.progress_detail,
+            result_detail=result_detail if result_detail is not None else task.result_detail,
+        )
+        self._refresh_task_table()
+        if self._selected_task_id == task_id:
+            self._refresh_details()
+
+    def _task_update_from_thread(
+        self,
+        task_id: str,
+        *,
+        status: str | None = None,
+        progress_detail: str | None = None,
+        result_detail: str | None = None,
+    ) -> None:
+        self.call_from_thread(
+            self._update_task,
+            task_id,
+            status=status,
+            progress_detail=progress_detail,
+            result_detail=result_detail,
+        )
+
+    def _refresh_task_table(self) -> None:
+        table = cast(DataTable[object], self.query_one("#tasks", DataTable))
+        previous_task_id = self._selected_task_id
+        table.clear(columns=False)
+        if not self._task_order:
+            self._selected_task_id = None
+            table.add_row(EMPTY, EMPTY, EMPTY, "No background tasks yet", key="empty-task")
+            self._ensure_active_table()
+            return
+
+        task_ids = list(reversed(self._task_order[-MAX_TASK_ROWS:]))
+        for task_id in task_ids:
+            task = self._tasks[task_id]
+            table.add_row(
+                task.kind,
+                format_task_status(task.status),
+                task.item,
+                summarize_task_detail(task),
+                key=task.task_id,
+            )
+
+        self._selected_task_id = self._restore_task_selection(table, previous_task_id, task_ids)
+        self._ensure_active_table()
+
+    def _status_from_thread(self, message: str) -> None:
+        self.call_from_thread(self._set_status, message)
+
+    def _set_status(self, message: str) -> None:
+        self.query_one("#status", Static).update(self._status_text(message))
+
+    def _on_filter_screen_dismissed(self, result: tuple[ArtifactProcessingState, ...] | None) -> None:
+        if result is None:
+            self._set_status("State filter unchanged.")
+            return
+
+        self.failure_states = result
+        self._load_current_snapshot(initial=False)
+        self._set_status(f"Updated state filter to {self._state_filter_label()}.")
+
+    def _on_reason_screen_dismissed(self, result: str | None) -> None:
+        if result is None:
+            self._set_status("Admin apply cancelled because no reason was provided.")
+            return
+        if self._pending_batch is None:
+            self._set_status("No pending batch to apply.")
+            return
+        self._pending_batch = with_pending_batch_reason(self._pending_batch, result)
+        self._refresh_pending_batch()
+        self._start_apply_thread(self._pending_batch)
+
+    def _subtitle(self) -> str:
+        current = self.current_snapshot_id or "none"
+        pending = self.pending_snapshot_id or "none"
+        states = self._state_filter_label()
+        if self._current_snapshot_info is None:
+            return f"current={current} | pending={pending} | states={states}"
+        return (
+            f"current={current} | pending={pending} | ipsw={self._current_snapshot_info.ipsw_generation} | "
+            f"ota={self._current_snapshot_info.ota_generation} | states={states}"
+        )
+
+    def _state_filter_label(self) -> str:
+        if not self.failure_states:
+            return "none"
+        return ",".join(state.value for state in self.failure_states)
+
+    def _restore_task_selection(
+        self,
+        table: DataTable[object],
+        previous_task_id: str | None,
+        task_ids: list[str],
+    ) -> str | None:
+        if not task_ids:
+            return None
+
+        target_task_id = previous_task_id if previous_task_id in task_ids else task_ids[0]
+        table.move_cursor(row=table.get_row_index(target_task_id), animate=False, scroll=False)
+        return target_task_id
+
+    def _status_text(self, message: str) -> str:
+        return (
+            f"{message}\n"
+            "Press 's' to refresh, 'u' to switch to the latest snapshot, 'f' to edit state filters, 'd' to queue a download, 'e'/'m' to build a rerun batch, 'a' to apply it, 'c' to clear it, 'q' to quit."
+        )
+
+
+def _download_selected_item(
+    row: IpswSourceRow | OtaArtifactRow,
+    cache_dir: Path,
+    status_callback: Callable[[str], None] | None = None,
+) -> ArtifactDownloadResult:
+    if isinstance(row, IpswSourceRow):
+        return download_ipsw_to_cache(row, cache_dir, status_callback=status_callback)
+    return download_ota_to_cache(row, cache_dir, status_callback=status_callback)
+
+
+def format_failure_table_title(label: str, count: int) -> str:
+    return f"{label} ({count})"
+
+
+def format_task_status(status: str) -> Text:
+    label, style = {
+        "queued": ("… queued", "yellow"),
+        "running": ("↻ running", "blue"),
+        "done": ("✓ done", "green"),
+        "warning": ("! warning", "yellow"),
+        "failed": ("✗ failed", "red"),
+    }.get(status, (status, "white"))
+    return Text(label, style=style)
+
+
+def summarize_task_detail(task: BackgroundTaskEntry, max_length: int = 56) -> str:
+    detail = task.result_detail or task.progress_detail
+    if len(detail) <= max_length:
+        return detail
+    return f"{detail[: max_length - 1]}…"
+
+
+def format_task_detail(task: BackgroundTaskEntry) -> str:
+    lines = [
+        "type: Background task",
+        f"task_id: {task.task_id}",
+        f"kind: {task.kind}",
+        f"status: {task.status}",
+        f"item: {task.item}",
+        f"latest_progress: {task.progress_detail}",
+    ]
+    if task.result_detail is not None:
+        lines.append(f"result: {task.result_detail}")
+    return "\n".join(lines)
+
+
+def format_ipsw_detail(row: IpswSourceRow) -> str:
+    return "\n".join(
+        [
+            "type: IPSW source",
+            f"state: {row.processing_state.value}",
+            f"platform: {row.platform}",
+            f"version: {row.version}",
+            f"build: {row.build}",
+            f"artifact_key: {row.artifact_key}",
+            f"file_name: {row.file_name}",
+            f"last_modified: {row.last_modified or EMPTY}",
+            f"last_run: #{row.last_run}",
+            f"sha1: {row.sha1 or EMPTY}",
+            f"mirror_path: {row.mirror_path or EMPTY}",
+            f"link: {row.link}",
+        ]
+    )
+
+
+def format_ota_detail(row: OtaArtifactRow, run_info: GithubRunInfo | None) -> str:
+    started_at = format_iso_timestamp(run_info.started_at) if run_info is not None and run_info.started_at else EMPTY
+    updated_at = format_iso_timestamp(run_info.updated_at) if run_info is not None and run_info.updated_at else EMPTY
+    run_url = run_info.url if run_info is not None and run_info.url else EMPTY
+    run_title = run_info.display_title if run_info is not None and run_info.display_title else EMPTY
+    return "\n".join(
+        [
+            "type: OTA artifact",
+            f"state: {row.processing_state.value}",
+            f"platform: {row.platform}",
+            f"version: {row.version}",
+            f"build: {row.build}",
+            f"ota_key: {row.ota_key}",
+            f"artifact_id: {row.artifact_id}",
+            f"last_run: #{row.last_run}",
+            f"last_run_at: {format_github_run_time(row.last_run, run_info)}",
+            f"hash: {row.hash}",
+            f"hash_algorithm: {row.hash_algorithm}",
+            f"run_title: {run_title}",
+            f"run_started_at: {started_at}",
+            f"run_updated_at: {updated_at}",
+            f"run_url: {run_url}",
+            f"download_path: {row.download_path or EMPTY}",
+            f"url: {row.url}",
+        ]
+    )
+
+
+def _ipsw_row_key(row: IpswSourceRow) -> str:
+    return f"{row.artifact_key}::{row.link}"
+
+
+def _ota_row_key(row: OtaArtifactRow) -> str:
+    return row.ota_key
+
+
+def should_auto_sync_on_start(
+    snapshot_info: SnapshotInfo | None,
+    now: datetime | None = None,
+    max_age: timedelta = AUTO_SYNC_MAX_AGE,
+) -> bool:
+    if snapshot_info is None:
+        return True
+
+    if now is None:
+        now = datetime.now(UTC)
+
+    try:
+        created_at = datetime.fromisoformat(snapshot_info.created_at)
+    except ValueError:
+        return True
+
+    return (now - created_at) >= max_age
+
+
+def launch_tui(cache_dir: Path, failure_states: tuple[ArtifactProcessingState, ...] = DEFAULT_FAILURE_STATES) -> None:
+    app = AdminTui(cache_dir=cache_dir, failure_states=failure_states)
+    app.run()

--- a/symx/admin/tui.py
+++ b/symx/admin/tui.py
@@ -275,6 +275,7 @@ class AdminTui(App[None]):
         self._sync_thread: threading.Thread | None = None
         self._sync_activate_latest = False
         self._apply_thread: threading.Thread | None = None
+        self._download_worker_lock = threading.Lock()
         self._download_worker_thread: threading.Thread | None = None
         self._run_lookup_thread: threading.Thread | None = None
         self._download_queue: Queue[DownloadQueueItem] = Queue()
@@ -832,11 +833,12 @@ class AdminTui(App[None]):
         self._set_status(result.message)
 
     def _start_download_worker(self) -> None:
-        if self._download_worker_thread is not None and self._download_worker_thread.is_alive():
-            return
+        with self._download_worker_lock:
+            if self._download_worker_thread is not None and self._download_worker_thread.is_alive():
+                return
 
-        self._download_worker_thread = threading.Thread(target=self._run_download_worker, daemon=True)
-        self._download_worker_thread.start()
+            self._download_worker_thread = threading.Thread(target=self._run_download_worker, daemon=True)
+            self._download_worker_thread.start()
 
     def _run_download_worker(self) -> None:
         try:
@@ -844,7 +846,9 @@ class AdminTui(App[None]):
                 try:
                     item = self._download_queue.get(timeout=0.2)
                 except Empty:
-                    return
+                    if self._finish_download_worker_if_idle():
+                        return
+                    continue
 
                 self._task_update_from_thread(item.task_id, status="running", progress_detail="Downloading")
                 self._status_from_thread(f"Downloading {item.item_label}…")
@@ -862,7 +866,17 @@ class AdminTui(App[None]):
                 finally:
                     self._download_queue.task_done()
         finally:
-            self._download_worker_thread = None
+            with self._download_worker_lock:
+                if self._download_worker_thread is threading.current_thread():
+                    self._download_worker_thread = None
+
+    def _finish_download_worker_if_idle(self) -> bool:
+        with self._download_worker_lock:
+            if not self._download_queue.empty():
+                return False
+            if self._download_worker_thread is threading.current_thread():
+                self._download_worker_thread = None
+            return True
 
     def _download_progress_from_thread(self, task_id: str, message: str) -> None:
         self.call_from_thread(self._update_task, task_id, progress_detail=message)

--- a/symx/diagnostics.py
+++ b/symx/diagnostics.py
@@ -1,0 +1,78 @@
+"""Shared helpers for formatting subprocess and filesystem diagnostics."""
+
+import shlex
+import subprocess
+from collections.abc import Sequence
+from pathlib import Path
+
+MAX_SUBPROCESS_OUTPUT_CHARS = 4_000
+DEFAULT_DIRECTORY_SAMPLE_ENTRIES = 20
+
+
+def decode_subprocess_output(output: str | bytes | None) -> str:
+    if output is None:
+        return ""
+    if isinstance(output, bytes):
+        return output.decode("utf-8", errors="replace")
+    return output
+
+
+def format_subprocess_output(
+    label: str,
+    output: str | bytes | None,
+    max_chars: int = MAX_SUBPROCESS_OUTPUT_CHARS,
+    indent: str = "    ",
+) -> str:
+    text = decode_subprocess_output(output).strip()
+    if not text:
+        return f"  {label}: <empty>"
+
+    if len(text) > max_chars:
+        omitted = len(text) - max_chars
+        text = f"{text[:max_chars]}\n... [truncated {omitted} chars]"
+
+    indented = "\n".join(f"{indent}{line}" for line in text.splitlines())
+    return f"  {label}:\n{indented}"
+
+
+def format_subprocess_result(
+    label: str,
+    result: subprocess.CompletedProcess[bytes] | subprocess.CompletedProcess[str] | None,
+) -> str:
+    if result is None:
+        return f"{label}: not attempted"
+
+    return "\n".join(
+        [
+            f"{label}: exit={result.returncode}",
+            format_subprocess_output("stdout", result.stdout),
+            format_subprocess_output("stderr", result.stderr),
+        ]
+    )
+
+
+def format_command(command: Sequence[str]) -> str:
+    return " ".join(shlex.quote(part) for part in command)
+
+
+def describe_directory(directory: Path, max_entries: int = DEFAULT_DIRECTORY_SAMPLE_ENTRIES, indent: str = "  ") -> str:
+    if not directory.exists():
+        return f"directory {directory}: <missing>"
+    if not directory.is_dir():
+        return f"directory {directory}: <not a directory>"
+
+    sample_entries: list[str] = []
+    for path in directory.rglob("*"):
+        suffix = "/" if path.is_dir() else ""
+        sample_entries.append(f"{path.relative_to(directory)}{suffix}")
+        if len(sample_entries) >= max_entries:
+            break
+
+    if not sample_entries:
+        return f"directory {directory}: (empty)"
+
+    lines = [f"directory {directory} sample entries:"]
+    lines.extend(f"{indent}{entry}" for entry in sample_entries)
+    if len(sample_entries) >= max_entries:
+        lines.append(f"{indent}... showing first {max_entries} entries")
+    return "\n".join(lines)

--- a/symx/download.py
+++ b/symx/download.py
@@ -2,6 +2,7 @@
 
 import logging
 import time as time_module
+from collections.abc import Callable
 from math import floor
 from pathlib import Path
 
@@ -13,12 +14,19 @@ from symx.model import MiB
 
 logger = logging.getLogger(__name__)
 
+StatusCallback = Callable[[str], None]
+
 
 class DownloadError(Exception):
     """Raised by `try_download_url_to_file` after all retries have failed."""
 
 
-def try_download_url_to_file(url: str, filepath: Path, num_retries: int = 5) -> None:
+def try_download_url_to_file(
+    url: str,
+    filepath: Path,
+    num_retries: int = 5,
+    status_callback: StatusCallback | None = None,
+) -> None:
     """Download `url` to `filepath`, retrying on failure.
 
     On total failure, raises `DownloadError` chained to the last underlying exception. Callers
@@ -29,14 +37,21 @@ def try_download_url_to_file(url: str, filepath: Path, num_retries: int = 5) -> 
     last_exc: Exception | None = None
     for attempt in range(num_retries):
         try:
-            download_url_to_file(url, filepath)
+            download_url_to_file(url, filepath, status_callback=status_callback)
             return
         except Exception as e:
             last_exc = e
             if attempt < num_retries - 1:
-                logger.info("Download failed, retrying", extra={"url": url, "attempt": attempt + 1})
+                _emit_status(
+                    f"Download failed, retrying ({attempt + 1}/{num_retries}) for {url}",
+                    status_callback,
+                )
 
-    logger.warning("Failed to download URL", extra={"url": url, "attempts": num_retries, "exception": last_exc})
+    _emit_status(
+        f"Failed to download {url} after {num_retries} attempts",
+        status_callback,
+        warning=True,
+    )
     raise DownloadError(f"Failed to download {url} after {num_retries} attempts") from last_exc
 
 
@@ -44,7 +59,7 @@ def try_download_url_to_file(url: str, filepath: Path, num_retries: int = 5) -> 
 DOWNLOAD_TIMEOUT = (10.0, 60.0)
 
 
-def download_url_to_file(url: str, filepath: Path) -> None:
+def download_url_to_file(url: str, filepath: Path, status_callback: StatusCallback | None = None) -> None:
     with sentry_sdk.start_span(op="http.download", name=f"Download {filepath.name}") as span:
         span.set_data("url", str(url))
         span.set_data("filepath", str(filepath))
@@ -54,11 +69,13 @@ def download_url_to_file(url: str, filepath: Path) -> None:
             res.raise_for_status()
             content_length = res.headers.get("content-length")
             if not content_length:
-                logger.warning("URL endpoint does not respond with a content-length header")
+                _emit_status(
+                    "URL endpoint does not respond with a content-length header", status_callback, warning=True
+                )
             else:
                 total = int(content_length)
                 total_mib = total / MiB
-                logger.info("Filesize: %dMiB", floor(total_mib))
+                _emit_status(f"Filesize: {floor(total_mib)}MiB", status_callback)
                 span.set_data("content_length_bytes", total)
 
             with open(filepath, "wb") as f:
@@ -71,12 +88,22 @@ def download_url_to_file(url: str, filepath: Path) -> None:
 
                     actual_mib = actual / MiB
                     if actual_mib - last_print > 100.0:
-                        logger.info("%dMiB", floor(actual_mib))
+                        _emit_status(f"Downloaded {floor(actual_mib)}MiB", status_callback)
                         last_print = actual_mib
 
-                logger.info("%dMiB", floor(actual_mib))
+                _emit_status(f"Downloaded {floor(actual_mib)}MiB", status_callback)
 
         elapsed = time_module.monotonic() - start
         span.set_data("downloaded_bytes", actual)
         sentry_sdk.metrics.distribution("download.size_bytes", actual, unit="byte")
         sentry_sdk.metrics.distribution("download.duration_seconds", elapsed, unit="second")
+
+
+def _emit_status(message: str, status_callback: StatusCallback | None, warning: bool = False) -> None:
+    if status_callback is not None:
+        status_callback(message)
+        return
+    if warning:
+        logger.warning(message)
+    else:
+        logger.info(message)

--- a/symx/download.py
+++ b/symx/download.py
@@ -101,6 +101,12 @@ def download_url_to_file(url: str, filepath: Path, status_callback: StatusCallba
 
 def _emit_status(message: str, status_callback: StatusCallback | None, warning: bool = False) -> None:
     if status_callback is not None:
+        # Intentional: a callback is an alternate output sink, not an addition to logging.
+        # The local admin TUI passes a callback so download progress/retry events stay inside
+        # the Textual UI instead of also being emitted via the normal logger, which would
+        # duplicate messages and can interfere with terminal rendering. The production runner
+        # paths do not pass a callback, so they still log normally and retain their existing
+        # observability behavior.
         status_callback(message)
         return
     if warning:

--- a/symx/fs.py
+++ b/symx/fs.py
@@ -3,6 +3,7 @@
 import hashlib
 import logging
 import shutil
+from collections.abc import Callable
 from math import floor
 from pathlib import Path
 
@@ -13,8 +14,10 @@ from symx.model import HASH_BLOCK_SIZE, MiB
 
 logger = logging.getLogger(__name__)
 
+StatusCallback = Callable[[str], None]
 
-def check_sha1(hash_sum: str, filepath: Path) -> bool:
+
+def check_sha1(hash_sum: str, filepath: Path, status_callback: StatusCallback | None = None) -> bool:
     sha1sum = hashlib.sha1()
     with open(filepath, "rb") as f:
         block = f.read(HASH_BLOCK_SIZE)
@@ -23,8 +26,15 @@ def check_sha1(hash_sum: str, filepath: Path) -> bool:
             block = f.read(HASH_BLOCK_SIZE)
 
     sha1sum_result = sha1sum.hexdigest()
-    logger.info("Calculated sha1", extra={"sha1": sha1sum_result, "expected_sha1": hash_sum})
+    _emit_status(f"Calculated sha1 {sha1sum_result} (expected {hash_sum})", status_callback)
     return sha1sum_result == hash_sum
+
+
+def _emit_status(message: str, status_callback: StatusCallback | None) -> None:
+    if status_callback is not None:
+        status_callback(message)
+        return
+    logger.info(message)
 
 
 def list_dirs_in(dir_path: Path) -> list[Path]:

--- a/symx/gcs.py
+++ b/symx/gcs.py
@@ -117,7 +117,13 @@ def upload_symbol_binaries(bucket: Bucket, platform: str, bundle_id: str, binary
         bundle_index_path = dest_blob_prefix / platform / "bundles" / bundle_id
         blob = bucket.blob(str(bundle_index_path))
         if blob.exists():
-            logger.warning("Bundle %s already exists in symbol store for %s", bundle_id, platform)
+            # This is expected on reruns: symbol uploads are intentionally additive and never overwrite
+            # files already present in the store.
+            logger.warning(
+                "Bundle %s already exists in symbol store for %s; continuing with additive upload",
+                bundle_id,
+                platform,
+            )
 
         duplicate_count = 0
         new_count = 0

--- a/symx/ipsw/extract.py
+++ b/symx/ipsw/extract.py
@@ -7,6 +7,7 @@ import logging
 
 import sentry_sdk
 
+from symx.diagnostics import describe_directory, format_command, format_subprocess_output, format_subprocess_result
 from symx.model import Arch
 from symx.tools import dyld_split, symsort
 from symx.ipsw.model import IpswPlatform
@@ -14,6 +15,23 @@ from symx.ipsw.model import IpswPlatform
 logger = logging.getLogger(__name__)
 
 mount_point_re = re.compile(r".*Press Ctrl\+C to unmount '(.*)'")
+
+
+def _format_ipsw_command_error(
+    reason: str,
+    command: list[str],
+    stdout: str | bytes | None,
+    stderr: str | bytes | None,
+    directories: list[Path],
+) -> str:
+    details = [
+        reason,
+        f"command: {format_command(command)}",
+        format_subprocess_output("stdout", stdout),
+        format_subprocess_output("stderr", stderr),
+    ]
+    details.extend(describe_directory(directory) for directory in directories)
+    return "\n".join(details)
 
 
 def _compress_directory(directory: Path) -> Path:
@@ -79,7 +97,7 @@ class IpswExtractor:
         ipsw_path: Path,
     ):
         self.bundle_id = generate_bundle_id(file_name)
-        self.prefix = _map_platform_to_prefix(platform)
+        self.prefix = map_platform_to_prefix(platform)
         self.platform = platform
         if not processing_dir.is_dir():
             raise ValueError(f"IPSW path is expected to be a directory: {processing_dir}")
@@ -94,7 +112,7 @@ class IpswExtractor:
     def symbols_dir(self) -> Path:
         return self.processing_dir / "symbols"
 
-    def _ipsw_extract_dsc(self, arch: Arch | None = None) -> Path | None:
+    def _ipsw_extract_dsc(self, arch: Arch | None = None) -> Path:
         arch_label = str(arch) if arch else "default"
         with sentry_sdk.start_span(
             op="subprocess.ipsw_extract",
@@ -117,30 +135,52 @@ class IpswExtractor:
                 command.append("-a")
                 command.append(str(arch))
 
-            # Start the process using Popen
             with subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE) as process:
                 try:
                     # IPSW extraction is typically finished in a couple of minutes. Everything beyond 20 minutes is probably
                     # stuck because the dmg mounter asks for a password or something similar.
                     stdout, stderr = process.communicate(timeout=(60 * 20))
                 except subprocess.TimeoutExpired:
-                    # the timeout above doesn't kill the process, so make sure it is gone
                     process.kill()
-                    # consume and log remaining output from stdout and stderr
                     stdout, stderr = process.communicate()
-                    ipsw_stdout = stdout.decode("utf-8")
-                    ipsw_stderr = stderr.decode("utf-8")
-                    logger.warning("ipsw timed out", extra={"ipsw_stdout": ipsw_stdout, "ipsw_stderr": ipsw_stderr})
                     span.set_status("deadline_exceeded")
-                    raise TimeoutError("IPSW extraction timed out and was terminated.")
+                    raise IpswExtractError(
+                        _format_ipsw_command_error(
+                            f"ipsw extract timed out after 1200s for {self.ipsw_path} ({arch_label})",
+                            command,
+                            stdout,
+                            stderr,
+                            [self.processing_dir],
+                        )
+                    )
 
                 if process.returncode != 0:
-                    error_msg = stderr.decode("utf-8")
                     span.set_status("internal_error")
-                    raise IpswExtractError(f"ipsw extract failed with {error_msg}")
+                    raise IpswExtractError(
+                        _format_ipsw_command_error(
+                            f"ipsw extract failed for {self.ipsw_path} ({arch_label}) with exit code {process.returncode}",
+                            command,
+                            stdout,
+                            stderr,
+                            [self.processing_dir],
+                        )
+                    )
 
             _log_directory_contents(self.processing_dir)
-            return find_extraction_dir(self.processing_dir)
+            extract_dir = find_extraction_dir(self.processing_dir)
+            if extract_dir is None:
+                span.set_status("internal_error")
+                raise IpswExtractError(
+                    _format_ipsw_command_error(
+                        f"ipsw extract produced no dyld_shared_cache extraction directory for {self.ipsw_path} ({arch_label})",
+                        command,
+                        stdout,
+                        stderr,
+                        [self.processing_dir],
+                    )
+                )
+
+            return extract_dir
 
     def run(self) -> Path:
         with sentry_sdk.start_span(op="ipsw.extract.sys_image", name="Symsort sys image"):
@@ -163,8 +203,6 @@ class IpswExtractor:
                     arch_span.set_data("arch", str(arch))
 
                     extract_dir = self._ipsw_extract_dsc(arch)
-                    if extract_dir is None:
-                        raise IpswExtractError(f"Couldn't find IPSW dyld_shared_cache extraction directory for {arch}")
                     _log_directory_contents(extract_dir)
 
                     split_dir = self._ipsw_split(extract_dir, arch)
@@ -191,8 +229,6 @@ class IpswExtractor:
             # We accumulate each architecture as a sub-dir in split_dir and let symsorter process them together
         else:
             extract_dir = self._ipsw_extract_dsc()
-            if extract_dir is None:
-                raise IpswExtractError("Couldn't find IPSW dyld_shared_cache extraction directory")
             _log_directory_contents(extract_dir)
 
             # Delete IPSW also in the non-macOS path since this is our contract to the caller
@@ -208,6 +244,7 @@ class IpswExtractor:
 
     def _symsort_sys_image(self) -> None:
         # mount the sys image (the process waits for sigint)
+        mount_output_lines: list[str] = []
         with sentry_sdk.start_span(op="subprocess.ipsw_mount", name="Mount sys image") as mount_span:
             mount_proc = subprocess.Popen(
                 ["ipsw", "mount", "sys", str(self.ipsw_path), "-V"],
@@ -223,6 +260,7 @@ class IpswExtractor:
                 line = mount_proc.stdout.readline()
                 if not line:
                     break
+                mount_output_lines.append(line.rstrip())
                 mount_point_match = mount_point_re.match(line)
                 if not mount_point_match:
                     continue
@@ -232,6 +270,12 @@ class IpswExtractor:
 
             if mount_point:
                 mount_span.set_data("mount_point", str(mount_point))
+            elif mount_output_lines:
+                logger.warning(
+                    "Could not determine sys image mount point for %s.\n%s",
+                    self.ipsw_path.name,
+                    format_subprocess_output("mount output", "\n".join(mount_output_lines)),
+                )
 
         try:
             # symsort the entire sys mount-point
@@ -266,7 +310,9 @@ class IpswExtractor:
                 break
 
         if dsc_root_file is None:
-            raise IpswExtractError(f"Failed to find dyld_shared_cache root-file in {extract_dir}")
+            raise IpswExtractError(
+                f"Failed to find dyld_shared_cache root-file in {extract_dir}\n{describe_directory(extract_dir)}"
+            )
 
         split_dir = self.processing_dir / "split_out"
         if arch is not None:
@@ -277,11 +323,20 @@ class IpswExtractor:
 
         result = dyld_split(dsc_root_file, split_dir_arch)
 
+        if result.returncode != 0:
+            raise IpswExtractError(
+                "\n".join(
+                    [
+                        f"ipsw dyld split failed for {dsc_root_file}",
+                        format_subprocess_result("dyld split", result),
+                        describe_directory(extract_dir),
+                        describe_directory(split_dir_arch),
+                    ]
+                )
+            )
+
         # we have very limited space on the GHA runners, so get rid of processed input data
         shutil.rmtree(extract_dir)
-
-        if result.returncode != 0:
-            raise IpswExtractError(f"ipsw dyld split failed with {result}")
 
         return split_dir
 
@@ -292,7 +347,16 @@ class IpswExtractor:
         result = symsort(output_dir, self.prefix, self.bundle_id, split_dir, ignore_errors)
 
         if result.returncode != 0:
-            raise IpswExtractError(f"Symsorter failed with {result}")
+            raise IpswExtractError(
+                "\n".join(
+                    [
+                        f"Symsorter failed for bundle {self.bundle_id}",
+                        format_subprocess_result("symsorter", result),
+                        describe_directory(split_dir),
+                        describe_directory(output_dir),
+                    ]
+                )
+            )
 
 
 class IpswExtractError(Exception):
@@ -330,7 +394,7 @@ def _log_directory_contents(directory: Path) -> None:
     logger.info("Contents of directory.", extra={"directory": directory, "contents": dir_contents})
 
 
-def _map_platform_to_prefix(ipsw_platform: IpswPlatform) -> str:
+def map_platform_to_prefix(ipsw_platform: IpswPlatform) -> str:
     # IPSWs differentiate between iPadOS and iOS while OTA doesn't, so we put them in the same prefix
     if ipsw_platform == IpswPlatform.IPADOS:
         prefix_platform = IpswPlatform.IOS

--- a/symx/ipsw/model.py
+++ b/symx/ipsw/model.py
@@ -46,7 +46,7 @@ class IpswSource(BaseModel):
     processing_state: ArtifactProcessingState = ArtifactProcessingState.INDEXED
     mirror_path: str | None = None
     last_run: int = github_run_id()
-    last_modified: datetime.datetime = datetime.datetime.today()
+    last_modified: datetime.datetime | None = datetime.datetime.today()
 
     @computed_field  # type: ignore[misc]
     @property

--- a/symx/ipsw/runners.py
+++ b/symx/ipsw/runners.py
@@ -271,8 +271,9 @@ def extract(
                     except Exception as e:
                         sentry_sdk.capture_exception(e)
                         logger.warning(
-                            "Symbol extraction failed for %s, continuing with the next one.",
+                            "Symbol extraction failed for %s: %s. Continuing with the next one.",
                             source.file_name,
+                            e,
                             extra={"artifact": artifact, "source": source, "exception": e},
                         )
                         artifact.sources[source_idx].processing_state = ArtifactProcessingState.SYMBOL_EXTRACTION_FAILED

--- a/symx/model.py
+++ b/symx/model.py
@@ -39,6 +39,16 @@ class Arch(StrEnum):
 
 
 class ArtifactProcessingState(StrEnum):
+    """Persisted processing states shared by the IPSW and OTA pipelines.
+
+    Important domain nuance:
+    - IPSW persists state per ``IpswSource``.
+    - OTA persists state per ``OtaArtifact``.
+
+    Most enum members are assigned by current automation. ``IGNORED`` is retained as a
+    manual/operator-only state and is not assigned by the checked-in workflows.
+    """
+
     # we retrieved metadata from apple and merged it with ours
     INDEXED = "indexed"
 
@@ -59,12 +69,6 @@ class ArtifactProcessingState(StrEnum):
     # we have meta-data that points to the mirror, but the file at the path is missing or can't be validated
     MIRROR_CORRUPT = "mirror_corrupt"
 
-    # we stored the extracted dyld_shared_cache (optimization, not implemented yet)
-    DSC_EXTRACTED = "dsc_extracted"
-
-    # there was no dyld_shared_cache in the artifact (for instance: because it was a partial update)
-    DSC_EXTRACTION_FAILED = "dsc_extraction_failed"
-
     # the artifact is a delta/patch OTA (contains image_patches/app_patches instead of full files)
     # these never contain a DSC and cannot be processed for symbols
     DELTA_OTA = "delta_ota"
@@ -80,11 +84,7 @@ class ArtifactProcessingState(StrEnum):
     # and it turns out there are debug-ids already present but with different hash or something similar.
     SYMBOL_EXTRACTION_FAILED = "symbol_extraction_failed"
 
-    # we already know that the bundle_id is too coarse to discriminate between sensible duplicates. we probably should
-    # merge rather ignore images that result in existing bundle-ids. until this is implemented we mark images with this.
-    BUNDLE_DUPLICATION_DETECTED = "bundle_duplication_detected"
-
-    # manually assigned to ignore artifact from any processing
+    # manual/operator-only concept, but not currently assigned in automation
     IGNORED = "ignored"
 
 

--- a/symx/ota/extract.py
+++ b/symx/ota/extract.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import sentry_sdk
 
+from symx.diagnostics import DEFAULT_DIRECTORY_SAMPLE_ENTRIES, describe_directory, format_subprocess_result
 from symx.model import Arch
 from symx.fs import list_dirs_in, rmdir_if_exists
 from symx.tools import dyld_split, symsort as common_symsort
@@ -25,45 +26,6 @@ from symx.ota.model import (
 
 logger = logging.getLogger(__name__)
 
-MAX_SUBPROCESS_OUTPUT_CHARS = 4_000
-MAX_EXTRACT_DIR_SAMPLE_ENTRIES = 20
-
-
-def _decode_subprocess_output(output: str | bytes | None) -> str:
-    if output is None:
-        return ""
-    if isinstance(output, bytes):
-        return output.decode("utf-8", errors="replace")
-    return output
-
-
-def _format_subprocess_output(label: str, output: str | bytes | None) -> str:
-    text = _decode_subprocess_output(output).strip()
-    if not text:
-        return f"  {label}: <empty>"
-
-    if len(text) > MAX_SUBPROCESS_OUTPUT_CHARS:
-        omitted = len(text) - MAX_SUBPROCESS_OUTPUT_CHARS
-        text = f"{text[:MAX_SUBPROCESS_OUTPUT_CHARS]}\n... [truncated {omitted} chars]"
-
-    indented = "\n".join(f"    {line}" for line in text.splitlines())
-    return f"  {label}:\n{indented}"
-
-
-def _format_subprocess_result(
-    label: str, result: subprocess.CompletedProcess[bytes] | subprocess.CompletedProcess[str] | None
-) -> str:
-    if result is None:
-        return f"{label}: not attempted"
-
-    return "\n".join(
-        [
-            f"{label}: exit={result.returncode}",
-            _format_subprocess_output("stdout", result.stdout),
-            _format_subprocess_output("stderr", result.stderr),
-        ]
-    )
-
 
 def _describe_extract_dirs(output_dir: Path) -> str:
     extract_dirs = list_dirs_in(output_dir)
@@ -77,21 +39,8 @@ def _describe_extract_dirs(output_dir: Path) -> str:
             lines.append(f"  contains at least one {DYLD_SHARED_CACHE}* file")
             continue
 
-        sample_entries: list[str] = []
-        for path in extract_dir.rglob("*"):
-            suffix = "/" if path.is_dir() else ""
-            sample_entries.append(f"{path.relative_to(extract_dir)}{suffix}")
-            if len(sample_entries) >= MAX_EXTRACT_DIR_SAMPLE_ENTRIES:
-                break
-
-        if not sample_entries:
-            lines.append("  (empty)")
-            continue
-
-        lines.append("  sample entries:")
-        lines.extend(f"    {entry}" for entry in sample_entries)
-        if len(sample_entries) >= MAX_EXTRACT_DIR_SAMPLE_ENTRIES:
-            lines.append(f"    ... showing first {MAX_EXTRACT_DIR_SAMPLE_ENTRIES} entries")
+        sample = describe_directory(extract_dir, max_entries=DEFAULT_DIRECTORY_SAMPLE_ENTRIES, indent="    ")
+        lines.extend(f"  {line}" for line in sample.splitlines())
 
     return "\n".join(lines)
 
@@ -106,8 +55,8 @@ def _format_extract_ota_error(
     return "\n".join(
         [
             reason,
-            _format_subprocess_result("literal extract", literal_result),
-            _format_subprocess_result("payloadv2 pattern extract", pattern_result),
+            format_subprocess_result("literal extract", literal_result),
+            format_subprocess_result("payloadv2 pattern extract", pattern_result),
             _describe_extract_dirs(output_dir),
             f"artifact: {artifact}",
         ]

--- a/symx/ota/model.py
+++ b/symx/ota/model.py
@@ -48,6 +48,8 @@ class OtaArtifact(BaseModel):
     hash_algorithm: str
 
     # currently the run_id of the GHA Workflow so we can look it up
+    # TODO: add a `last_modified` field like IPSW has and migrate old meta-data offline by
+    #  hydrating it from the existing JSON plus `last_run`/fetch context where available.
     last_run: int = github_run_id()
     processing_state: ArtifactProcessingState = ArtifactProcessingState.INDEXED
 

--- a/tests/test_admin_actions.py
+++ b/tests/test_admin_actions.py
@@ -1,0 +1,100 @@
+from symx.admin.actions import (
+    AdminActionKind,
+    AdminStore,
+    ApplyBatchRequest,
+    ApplyBatchResult,
+    ApplyBatchStatus,
+    IpswTarget,
+    OtaTarget,
+    PendingBatch,
+    WorkerDispatchResult,
+    WorkerDispatchStatus,
+    bind_pending_batch,
+    preview_action,
+    snapshot_generation_for_store,
+)
+from symx.admin.db import SnapshotInfo
+from symx.model import ArtifactProcessingState
+
+
+def test_preview_action_requires_existing_path_for_extract_and_blocks_curated_exclusions() -> None:
+    missing_path = preview_action(
+        AdminStore.IPSW,
+        AdminActionKind.QUEUE_EXTRACT,
+        ArtifactProcessingState.SYMBOLS_EXTRACTED,
+        has_required_path=False,
+    )
+    excluded = preview_action(
+        AdminStore.OTA,
+        AdminActionKind.QUEUE_MIRROR,
+        ArtifactProcessingState.RECOVERY_OTA,
+        has_required_path=True,
+    )
+    already_eligible = preview_action(
+        AdminStore.OTA,
+        AdminActionKind.QUEUE_MIRROR,
+        ArtifactProcessingState.INDEXED,
+        has_required_path=False,
+    )
+
+    assert missing_path.allowed is False
+    assert "mirror_path" in missing_path.note
+    assert excluded.allowed is False
+    assert "excluded" in excluded.note
+    assert already_eligible.allowed is True
+    assert already_eligible.resulting_state == ArtifactProcessingState.INDEXED
+    assert "already eligible" in already_eligible.note
+
+
+def test_bind_pending_batch_uses_store_generation_and_requires_reason() -> None:
+    snapshot = SnapshotInfo(
+        snapshot_id="ipsw-101__ota-202",
+        created_at="2024-09-03T12:00:00+00:00",
+        workflow_run_id=1,
+        workflow_run_url=None,
+        ipsw_generation=101,
+        ota_generation=202,
+    )
+    batch = PendingBatch(
+        store=AdminStore.IPSW,
+        action=AdminActionKind.QUEUE_EXTRACT,
+        targets=(IpswTarget(artifact_key="iOS_18.0_22A100", link="https://example.invalid/test.ipsw"),),
+        reason="retry after extractor fix",
+    )
+
+    request = bind_pending_batch(batch, snapshot)
+
+    assert request.snapshot_id == snapshot.snapshot_id
+    assert request.base_generation == snapshot_generation_for_store(snapshot, AdminStore.IPSW)
+    assert request.reason == batch.reason
+
+
+def test_apply_batch_request_and_result_round_trip() -> None:
+    request = ApplyBatchRequest(
+        store=AdminStore.OTA,
+        action=AdminActionKind.QUEUE_MIRROR,
+        snapshot_id="ipsw-11__ota-22",
+        base_generation=22,
+        reason="retry mirror",
+        targets=(OtaTarget(ota_key="ota-key"),),
+    )
+    result = ApplyBatchResult(
+        status=ApplyBatchStatus.APPLIED_WITH_WORKER_WARNING,
+        store=request.store,
+        action=request.action,
+        snapshot_id=request.snapshot_id,
+        base_generation=request.base_generation,
+        remote_generation=22,
+        targets=request.targets,
+        reason=request.reason,
+        applied_count=1,
+        message="Applied with a warning",
+        worker=WorkerDispatchResult(
+            workflow="symx-ota-mirror.yml",
+            status=WorkerDispatchStatus.DISPATCH_FAILED,
+            detail="gh failed",
+        ),
+    )
+
+    assert ApplyBatchRequest.from_json(request.to_json()) == request
+    assert ApplyBatchResult.from_json(result.to_json()) == result

--- a/tests/test_admin_actions.py
+++ b/tests/test_admin_actions.py
@@ -1,3 +1,5 @@
+import pytest
+
 from symx.admin.actions import (
     AdminActionKind,
     AdminStore,
@@ -98,3 +100,11 @@ def test_apply_batch_request_and_result_round_trip() -> None:
 
     assert ApplyBatchRequest.from_json(request.to_json()) == request
     assert ApplyBatchResult.from_json(result.to_json()) == result
+
+
+def test_apply_batch_request_rejects_boolean_integer_payloads() -> None:
+    with pytest.raises(ValueError, match="Unexpected integer payload"):
+        ApplyBatchRequest.from_json(
+            '{"store":"ota","action":"queue_mirror","snapshot_id":"ipsw-1__ota-2","base_generation":true,'
+            '"reason":"retry mirror","targets":[{"ota_key":"ota-key"}]}'
+        )

--- a/tests/test_admin_apply.py
+++ b/tests/test_admin_apply.py
@@ -1,0 +1,132 @@
+from datetime import date, datetime
+
+import pytest
+from pydantic import HttpUrl
+
+from symx.admin.actions import AdminActionKind, AdminStore, ApplyBatchRequest, IpswTarget, OtaTarget
+from symx.admin.apply import AdminApplyValidationError, apply_request_to_ipsw_db, apply_request_to_ota_meta
+from symx.ipsw.model import (
+    IpswArtifact,
+    IpswArtifactDb,
+    IpswArtifactHashes,
+    IpswPlatform,
+    IpswReleaseStatus,
+    IpswSource,
+)
+from symx.model import ArtifactProcessingState
+from symx.ota.model import OtaArtifact
+
+
+def _make_ipsw_db() -> IpswArtifactDb:
+    return IpswArtifactDb(
+        artifacts={
+            "iOS_18.0_22A100": IpswArtifact(
+                platform=IpswPlatform.IOS,
+                version="18.0",
+                build="22A100",
+                released=date(2024, 9, 1),
+                release_status=IpswReleaseStatus.RELEASE,
+                sources=[
+                    IpswSource(
+                        devices=["iPhone17,1"],
+                        link=HttpUrl("https://updates.cdn-apple.com/test.ipsw"),
+                        hashes=IpswArtifactHashes(sha1="abc", sha2=None),
+                        size=123,
+                        processing_state=ArtifactProcessingState.SYMBOLS_EXTRACTED,
+                        mirror_path="mirror/ipsw/iOS/18.0/22A100/test.ipsw",
+                        last_run=111,
+                        last_modified=datetime(2024, 9, 3, 12, 0, 0),
+                    )
+                ],
+            )
+        }
+    )
+
+
+def _make_ota_meta() -> dict[str, OtaArtifact]:
+    return {
+        "ota-key": OtaArtifact(
+            build="22A100",
+            description=["full"],
+            version="18.0",
+            platform="ios",
+            id="ota-id",
+            url="https://updates.cdn-apple.com/ota-id.zip",
+            download_path="mirror/ota/ios/18.0/22A100/ota-id.zip",
+            devices=["iPhone17,1"],
+            hash="def",
+            hash_algorithm="SHA-1",
+            last_run=222,
+            processing_state=ArtifactProcessingState.SYMBOLS_EXTRACTED,
+        )
+    }
+
+
+def test_apply_request_to_ipsw_db_updates_processing_state_and_last_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GITHUB_RUN_ID", "999")
+    ipsw_db = _make_ipsw_db()
+    request = ApplyBatchRequest(
+        store=AdminStore.IPSW,
+        action=AdminActionKind.QUEUE_EXTRACT,
+        snapshot_id="ipsw-101__ota-202",
+        base_generation=101,
+        reason="retry extract",
+        targets=(IpswTarget(artifact_key="iOS_18.0_22A100", link="https://updates.cdn-apple.com/test.ipsw"),),
+    )
+
+    applied_count = apply_request_to_ipsw_db(ipsw_db, request)
+
+    source = ipsw_db.artifacts["iOS_18.0_22A100"].sources[0]
+    assert applied_count == 1
+    assert source.processing_state == ArtifactProcessingState.MIRRORED
+    assert source.last_run == 999
+
+
+def test_apply_request_to_ota_meta_updates_processing_state_and_last_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GITHUB_RUN_ID", "444")
+    ota_meta = _make_ota_meta()
+    request = ApplyBatchRequest(
+        store=AdminStore.OTA,
+        action=AdminActionKind.QUEUE_MIRROR,
+        snapshot_id="ipsw-101__ota-202",
+        base_generation=202,
+        reason="retry mirror",
+        targets=(OtaTarget(ota_key="ota-key"),),
+    )
+
+    applied_count = apply_request_to_ota_meta(ota_meta, request)
+
+    artifact = ota_meta["ota-key"]
+    assert applied_count == 1
+    assert artifact.processing_state == ArtifactProcessingState.INDEXED
+    assert artifact.last_run == 444
+
+
+def test_apply_request_validation_is_strict_for_missing_path_and_excluded_states() -> None:
+    ipsw_db = _make_ipsw_db()
+    ipsw_db.artifacts["iOS_18.0_22A100"].sources[0].mirror_path = None
+    ota_meta = _make_ota_meta()
+    ota_meta["ota-key"].processing_state = ArtifactProcessingState.RECOVERY_OTA
+
+    ipsw_request = ApplyBatchRequest(
+        store=AdminStore.IPSW,
+        action=AdminActionKind.QUEUE_EXTRACT,
+        snapshot_id="ipsw-101__ota-202",
+        base_generation=101,
+        reason="retry extract",
+        targets=(IpswTarget(artifact_key="iOS_18.0_22A100", link="https://updates.cdn-apple.com/test.ipsw"),),
+    )
+    ota_request = ApplyBatchRequest(
+        store=AdminStore.OTA,
+        action=AdminActionKind.QUEUE_MIRROR,
+        snapshot_id="ipsw-101__ota-202",
+        base_generation=202,
+        reason="retry mirror",
+        targets=(OtaTarget(ota_key="ota-key"),),
+    )
+
+    with pytest.raises(AdminApplyValidationError, match="mirror_path is required"):
+        apply_request_to_ipsw_db(ipsw_db, ipsw_request)
+
+    with pytest.raises(AdminApplyValidationError, match="excluded"):
+        apply_request_to_ota_meta(ota_meta, ota_request)

--- a/tests/test_admin_db.py
+++ b/tests/test_admin_db.py
@@ -1,0 +1,217 @@
+from datetime import date, datetime
+from pathlib import Path
+
+from pydantic import HttpUrl
+
+from symx.admin.db import (
+    DEFAULT_FAILURE_STATES,
+    SnapshotManifest,
+    build_snapshot_db,
+    load_ipsw_failures,
+    load_ipsw_rows,
+    load_ota_failures,
+    load_ota_rows,
+    load_snapshot_info,
+    make_snapshot_id,
+    read_manifest,
+    snapshot_paths,
+    write_manifest,
+)
+from symx.ipsw.model import (
+    IpswArtifact,
+    IpswArtifactDb,
+    IpswArtifactHashes,
+    IpswPlatform,
+    IpswReleaseStatus,
+    IpswSource,
+)
+from symx.model import ArtifactProcessingState
+from symx.ota.model import OtaArtifact
+
+
+def _ipsw_source(
+    file_name: str,
+    processing_state: ArtifactProcessingState,
+    last_run: int,
+    last_modified: datetime,
+    link: str | None = None,
+) -> IpswSource:
+    source = IpswSource(
+        devices=["iPhone17,1"],
+        link=HttpUrl(link or f"https://updates.cdn-apple.com/{file_name}"),
+        hashes=IpswArtifactHashes(sha1=f"sha1-{file_name}", sha2=None),
+        size=123,
+        processing_state=processing_state,
+        mirror_path=f"mirror/{file_name}" if processing_state == ArtifactProcessingState.MIRRORED else None,
+        last_run=last_run,
+        last_modified=last_modified,
+    )
+    return source
+
+
+def _ota_artifact(
+    artifact_id: str,
+    processing_state: ArtifactProcessingState,
+    last_run: int,
+) -> OtaArtifact:
+    return OtaArtifact(
+        build="22A100",
+        description=["full"],
+        version="18.0",
+        platform="ios",
+        id=artifact_id,
+        url=f"https://updates.cdn-apple.com/{artifact_id}.zip",
+        download_path=None,
+        devices=["iPhone17,1"],
+        hash=f"hash-{artifact_id}",
+        hash_algorithm="SHA-1",
+        last_run=last_run,
+        processing_state=processing_state,
+    )
+
+
+def test_build_snapshot_db_and_query_failures(tmp_path: Path) -> None:
+    snapshot_id = make_snapshot_id(101, 202)
+    paths = snapshot_paths(tmp_path, snapshot_id)
+    paths.root.mkdir(parents=True)
+
+    ipsw_db = IpswArtifactDb(
+        artifacts={
+            "iOS_18.0_22A100": IpswArtifact(
+                platform=IpswPlatform.IOS,
+                version="18.0",
+                build="22A100",
+                released=date(2024, 9, 1),
+                release_status=IpswReleaseStatus.RELEASE,
+                sources=[
+                    _ipsw_source(
+                        "newest.ipsw",
+                        ArtifactProcessingState.SYMBOL_EXTRACTION_FAILED,
+                        last_run=300,
+                        last_modified=datetime(2024, 9, 3, 12, 0, 0),
+                    ),
+                    _ipsw_source(
+                        "newest.ipsw",
+                        ArtifactProcessingState.MIRRORING_FAILED,
+                        last_run=200,
+                        last_modified=datetime(2024, 9, 2, 12, 0, 0),
+                        link="https://updates.cdn-apple.com/alternate/newest.ipsw",
+                    ),
+                    _ipsw_source(
+                        "ok.ipsw",
+                        ArtifactProcessingState.MIRRORED,
+                        last_run=100,
+                        last_modified=datetime(2024, 9, 1, 12, 0, 0),
+                    ),
+                ],
+            )
+        }
+    )
+    ota_meta = {
+        "ota-newest": _ota_artifact("ota-newest", ArtifactProcessingState.INDEXED_INVALID, last_run=400),
+        "ota-older": _ota_artifact("ota-older", ArtifactProcessingState.SYMBOL_EXTRACTION_FAILED, last_run=300),
+        "ota-ok": _ota_artifact("ota-ok", ArtifactProcessingState.MIRRORED, last_run=100),
+    }
+
+    build_snapshot_db(
+        paths.db_path,
+        snapshot_id,
+        ipsw_db,
+        ipsw_generation=101,
+        ota_meta=ota_meta,
+        ota_generation=202,
+        workflow_run_id=999,
+        workflow_run_url="https://github.example/run/999",
+    )
+
+    snapshot_info = load_snapshot_info(paths.db_path)
+    assert snapshot_info is not None
+    assert snapshot_info.snapshot_id == snapshot_id
+    assert snapshot_info.workflow_run_id == 999
+    assert snapshot_info.ipsw_generation == 101
+    assert snapshot_info.ota_generation == 202
+
+    ipsw_failures = load_ipsw_failures(paths.db_path)
+    assert [row.file_name for row in ipsw_failures] == ["newest.ipsw", "newest.ipsw"]
+    assert [row.link for row in ipsw_failures] == [
+        "https://updates.cdn-apple.com/newest.ipsw",
+        "https://updates.cdn-apple.com/alternate/newest.ipsw",
+    ]
+    assert [row.processing_state for row in ipsw_failures] == [
+        ArtifactProcessingState.SYMBOL_EXTRACTION_FAILED,
+        ArtifactProcessingState.MIRRORING_FAILED,
+    ]
+
+    ota_failures = load_ota_failures(paths.db_path)
+    assert [row.ota_key for row in ota_failures] == ["ota-newest", "ota-older"]
+    assert [row.last_run for row in ota_failures] == [400, 300]
+
+
+def test_row_queries_return_all_rows_by_default(tmp_path: Path) -> None:
+    snapshot_id = make_snapshot_id(303, 404)
+    paths = snapshot_paths(tmp_path, snapshot_id)
+    paths.root.mkdir(parents=True)
+
+    ipsw_sources = [
+        _ipsw_source(
+            f"failure-{index:02d}.ipsw",
+            ArtifactProcessingState.SYMBOL_EXTRACTION_FAILED,
+            last_run=1000 + index,
+            last_modified=datetime(2024, 9, index + 1, 12, 0, 0),
+        )
+        for index in range(12)
+    ]
+    ipsw_db = IpswArtifactDb(
+        artifacts={
+            "iOS_18.1_22B100": IpswArtifact(
+                platform=IpswPlatform.IOS,
+                version="18.1",
+                build="22B100",
+                released=date(2024, 10, 1),
+                release_status=IpswReleaseStatus.RELEASE,
+                sources=ipsw_sources,
+            )
+        }
+    )
+    ota_meta = {
+        f"ota-{index:02d}": _ota_artifact(
+            f"ota-{index:02d}",
+            ArtifactProcessingState.INDEXED_INVALID,
+            last_run=2000 + index,
+        )
+        for index in range(12)
+    }
+
+    build_snapshot_db(
+        paths.db_path,
+        snapshot_id,
+        ipsw_db,
+        ipsw_generation=303,
+        ota_meta=ota_meta,
+        ota_generation=404,
+        workflow_run_id=1001,
+        workflow_run_url="https://github.example/run/1001",
+    )
+
+    assert len(load_ipsw_rows(paths.db_path)) == 12
+    assert len(load_ota_rows(paths.db_path)) == 12
+    assert len(load_ipsw_rows(paths.db_path, limit=5)) == 5
+    assert len(load_ota_rows(paths.db_path, limit=5)) == 5
+
+
+def test_default_failure_states_track_currently_emitted_states() -> None:
+    assert DEFAULT_FAILURE_STATES == (
+        ArtifactProcessingState.MIRRORING_FAILED,
+        ArtifactProcessingState.MIRROR_CORRUPT,
+        ArtifactProcessingState.SYMBOL_EXTRACTION_FAILED,
+        ArtifactProcessingState.INDEXED_INVALID,
+    )
+
+
+def test_manifest_round_trip(tmp_path: Path) -> None:
+    assert read_manifest(tmp_path).active_snapshot_id is None
+
+    write_manifest(tmp_path, SnapshotManifest(active_snapshot_id="ipsw-1__ota-2"))
+
+    manifest = read_manifest(tmp_path)
+    assert manifest.active_snapshot_id == "ipsw-1__ota-2"

--- a/tests/test_admin_db.py
+++ b/tests/test_admin_db.py
@@ -147,6 +147,46 @@ def test_build_snapshot_db_and_query_failures(tmp_path: Path) -> None:
     assert [row.last_run for row in ota_failures] == [400, 300]
 
 
+def test_build_snapshot_db_allows_missing_source_last_modified(tmp_path: Path) -> None:
+    snapshot_id = make_snapshot_id(909, 1001)
+    paths = snapshot_paths(tmp_path, snapshot_id)
+    paths.root.mkdir(parents=True)
+
+    source = _ipsw_source(
+        "missing-last-modified.ipsw",
+        ArtifactProcessingState.SYMBOL_EXTRACTION_FAILED,
+        last_run=300,
+        last_modified=datetime(2024, 9, 3, 12, 0, 0),
+    ).model_copy(update={"last_modified": None})
+    ipsw_db = IpswArtifactDb(
+        artifacts={
+            "iOS_18.0_22A100": IpswArtifact(
+                platform=IpswPlatform.IOS,
+                version="18.0",
+                build="22A100",
+                released=date(2024, 9, 1),
+                release_status=IpswReleaseStatus.RELEASE,
+                sources=[source],
+            )
+        }
+    )
+
+    build_snapshot_db(
+        paths.db_path,
+        snapshot_id,
+        ipsw_db,
+        ipsw_generation=909,
+        ota_meta={},
+        ota_generation=1001,
+        workflow_run_id=123,
+        workflow_run_url="https://github.example/run/123",
+    )
+
+    rows = load_ipsw_rows(paths.db_path)
+    assert len(rows) == 1
+    assert rows[0].last_modified is None
+
+
 def test_row_queries_return_all_rows_by_default(tmp_path: Path) -> None:
     snapshot_id = make_snapshot_id(303, 404)
     paths = snapshot_paths(tmp_path, snapshot_id)

--- a/tests/test_admin_downloads.py
+++ b/tests/test_admin_downloads.py
@@ -1,0 +1,94 @@
+import hashlib
+from pathlib import Path
+from unittest.mock import patch
+
+from symx.admin.db import IpswFailureRow, OtaFailureRow
+from symx.admin.downloads import download_ipsw_to_cache, download_ota_to_cache, infer_file_name_from_url
+from symx.model import ArtifactProcessingState
+
+
+def test_infer_file_name_from_url_prefers_query_path() -> None:
+    url = (
+        "https://developer.apple.com/services-account/download?"
+        "path=/WWDC_2020/iOS_14_beta/iPhone_4.7_14.0_18A5301v_Restore.ipsw"
+    )
+
+    assert infer_file_name_from_url(url) == "iPhone_4.7_14.0_18A5301v_Restore.ipsw"
+
+
+def test_download_ipsw_to_cache_verifies_sha1(tmp_path: Path) -> None:
+    payload = b"ipsw-bytes"
+    row = IpswFailureRow(
+        last_modified="2024-09-03T12:34:56",
+        processing_state=ArtifactProcessingState.SYMBOL_EXTRACTION_FAILED,
+        platform="iOS",
+        version="18.0",
+        build="22A100",
+        artifact_key="iOS_18.0_22A100",
+        file_name="test.ipsw",
+        link="https://updates.cdn-apple.com/test.ipsw",
+        sha1=hashlib.sha1(payload).hexdigest(),
+        last_run=123,
+        mirror_path=None,
+    )
+
+    messages: list[str] = []
+
+    with patch("symx.admin.downloads.try_download_url_to_file") as download_file:
+        download_file.side_effect = lambda url, path, status_callback=None: path.write_bytes(payload)
+        result = download_ipsw_to_cache(row, tmp_path, status_callback=messages.append)
+
+    assert result.verified is True
+    assert result.path.exists()
+    assert result.path.read_bytes() == payload
+    assert any("Verifying IPSW SHA-1" in message for message in messages)
+
+
+def test_download_ipsw_to_cache_allows_unverified_download(tmp_path: Path) -> None:
+    payload = b"ipsw-bytes"
+    row = IpswFailureRow(
+        last_modified="2024-09-03T12:34:56",
+        processing_state=ArtifactProcessingState.SYMBOL_EXTRACTION_FAILED,
+        platform="iOS",
+        version="18.0",
+        build="22A100",
+        artifact_key="iOS_18.0_22A100",
+        file_name="download",
+        link="https://developer.apple.com/services-account/download?path=/foo/bar/Test_Restore.ipsw",
+        sha1=None,
+        last_run=123,
+        mirror_path=None,
+    )
+
+    with patch("symx.admin.downloads.try_download_url_to_file") as download_file:
+        download_file.side_effect = lambda url, path, status_callback=None: path.write_bytes(payload)
+        result = download_ipsw_to_cache(row, tmp_path)
+
+    assert result.verified is False
+    assert "without SHA verification" in result.message
+    assert result.path.name.endswith("Test_Restore.ipsw")
+
+
+def test_download_ota_to_cache_verifies_sha1(tmp_path: Path) -> None:
+    payload = b"ota-bytes"
+    row = OtaFailureRow(
+        last_run=456,
+        processing_state=ArtifactProcessingState.INDEXED_INVALID,
+        platform="ios",
+        version="18.0",
+        build="22A100",
+        ota_key="ota-key",
+        artifact_id="ota-id",
+        url="https://updates.cdn-apple.com/test.zip",
+        hash=hashlib.sha1(payload).hexdigest(),
+        hash_algorithm="SHA-1",
+        download_path=None,
+    )
+
+    with patch("symx.admin.downloads.try_download_url_to_file") as download_file:
+        download_file.side_effect = lambda url, path, status_callback=None: path.write_bytes(payload)
+        result = download_ota_to_cache(row, tmp_path)
+
+    assert result.verified is True
+    assert result.path.exists()
+    assert result.path.read_bytes() == payload

--- a/tests/test_admin_executor.py
+++ b/tests/test_admin_executor.py
@@ -1,0 +1,136 @@
+import json
+import subprocess
+from pathlib import Path
+
+from symx.admin.actions import (
+    AdminActionKind,
+    AdminStore,
+    ApplyBatchRequest,
+    ApplyBatchResult,
+    ApplyBatchStatus,
+    OtaTarget,
+)
+from symx.admin.executor import ADMIN_APPLY_ARTIFACT, ADMIN_APPLY_RESULT_FILE, run_apply
+
+
+class _FakeGh:
+    def __init__(self, *, artifacts_by_run: dict[int, bool], result_by_run: dict[int, ApplyBatchResult]) -> None:
+        self.artifacts_by_run = artifacts_by_run
+        self.result_by_run = result_by_run
+        self.dispatches: list[list[str]] = []
+
+    def __call__(self, args: list[str]) -> subprocess.CompletedProcess[str]:
+        if args[:2] == ["workflow", "run"]:
+            self.dispatches.append(args)
+            return subprocess.CompletedProcess(["gh", *args], 0, "", "")
+
+        if args[:2] == ["api", "repos/{owner}/{repo}/actions/runs/600/artifacts"]:
+            return self._artifact_response(600, args)
+        if args[:2] == ["api", "repos/{owner}/{repo}/actions/runs/601/artifacts"]:
+            return self._artifact_response(601, args)
+
+        if args[:2] == ["run", "download"]:
+            run_id = int(args[2])
+            download_dir = Path(args[args.index("--dir") + 1])
+            download_dir.mkdir(parents=True, exist_ok=True)
+            (download_dir / ADMIN_APPLY_RESULT_FILE).write_text(self.result_by_run[run_id].to_json())
+            return subprocess.CompletedProcess(["gh", *args], 0, "", "")
+
+        return subprocess.CompletedProcess(["gh", *args], 0, "", "")
+
+    def _artifact_response(self, run_id: int, args: list[str]) -> subprocess.CompletedProcess[str]:
+        artifacts = []
+        if self.artifacts_by_run.get(run_id, False):
+            artifacts.append({"name": ADMIN_APPLY_ARTIFACT})
+        return subprocess.CompletedProcess(["gh", *args], 0, json.dumps({"artifacts": artifacts}), "")
+
+
+def test_run_apply_returns_structured_stale_generation_result(monkeypatch) -> None:
+    request = ApplyBatchRequest(
+        store=AdminStore.OTA,
+        action=AdminActionKind.QUEUE_MIRROR,
+        snapshot_id="ipsw-101__ota-202",
+        base_generation=202,
+        reason="retry mirror",
+        targets=(OtaTarget(ota_key="ota-key"),),
+    )
+    expected = ApplyBatchResult(
+        status=ApplyBatchStatus.STALE_GENERATION,
+        store=request.store,
+        action=request.action,
+        snapshot_id=request.snapshot_id,
+        base_generation=request.base_generation,
+        remote_generation=303,
+        targets=request.targets,
+        reason=request.reason,
+        applied_count=0,
+        message="stale",
+        worker=None,
+    )
+    fake_gh = _FakeGh(artifacts_by_run={600: True}, result_by_run={600: expected})
+
+    monkeypatch.setattr("symx.admin.executor._list_workflow_runs", lambda workflow, limit: [])
+    monkeypatch.setattr("symx.admin.executor._run_gh_command", fake_gh)
+    monkeypatch.setattr(
+        "symx.admin.executor._wait_for_new_run",
+        lambda workflow, before_max_run_id: {"databaseId": 600, "url": "https://example.invalid/run/600"},
+    )
+    monkeypatch.setattr(
+        "symx.admin.executor._wait_for_run_completion",
+        lambda workflow, run_id, status_callback: {
+            "databaseId": run_id,
+            "url": f"https://example.invalid/run/{run_id}",
+            "status": "completed",
+            "conclusion": "failure",
+        },
+    )
+
+    result = run_apply(request)
+
+    assert result == expected
+    assert any(arg == f"request_json={request.to_json()}" for arg in fake_gh.dispatches[0])
+
+
+def test_run_apply_returns_success_result(monkeypatch) -> None:
+    request = ApplyBatchRequest(
+        store=AdminStore.OTA,
+        action=AdminActionKind.QUEUE_EXTRACT,
+        snapshot_id="ipsw-101__ota-202",
+        base_generation=202,
+        reason="retry extract",
+        targets=(OtaTarget(ota_key="ota-key"),),
+    )
+    expected = ApplyBatchResult(
+        status=ApplyBatchStatus.APPLIED,
+        store=request.store,
+        action=request.action,
+        snapshot_id=request.snapshot_id,
+        base_generation=request.base_generation,
+        remote_generation=202,
+        targets=request.targets,
+        reason=request.reason,
+        applied_count=1,
+        message="applied",
+        worker=None,
+    )
+    fake_gh = _FakeGh(artifacts_by_run={601: True}, result_by_run={601: expected})
+
+    monkeypatch.setattr("symx.admin.executor._list_workflow_runs", lambda workflow, limit: [])
+    monkeypatch.setattr("symx.admin.executor._run_gh_command", fake_gh)
+    monkeypatch.setattr(
+        "symx.admin.executor._wait_for_new_run",
+        lambda workflow, before_max_run_id: {"databaseId": 601, "url": "https://example.invalid/run/601"},
+    )
+    monkeypatch.setattr(
+        "symx.admin.executor._wait_for_run_completion",
+        lambda workflow, run_id, status_callback: {
+            "databaseId": run_id,
+            "url": f"https://example.invalid/run/{run_id}",
+            "status": "completed",
+            "conclusion": "success",
+        },
+    )
+
+    result = run_apply(request)
+
+    assert result == expected

--- a/tests/test_admin_github.py
+++ b/tests/test_admin_github.py
@@ -1,0 +1,80 @@
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from symx.admin.github import (
+    GithubRunInfo,
+    ensure_github_run_infos,
+    fetch_github_run_info,
+    format_github_run_time,
+    read_github_run_cache,
+    write_github_run_cache,
+)
+
+
+def test_github_run_cache_round_trip(tmp_path: Path) -> None:
+    cache = {
+        123: GithubRunInfo(
+            run_id=123,
+            started_at="2024-09-03T10:00:00Z",
+            updated_at="2024-09-03T12:34:56Z",
+            url="https://example.invalid/run/123",
+            status="completed",
+            conclusion="failure",
+            display_title="OTA extract",
+        )
+    }
+
+    write_github_run_cache(tmp_path, cache)
+
+    loaded = read_github_run_cache(tmp_path)
+    assert loaded == cache
+
+
+def test_format_github_run_time_prefers_timestamp() -> None:
+    info = GithubRunInfo(run_id=123, updated_at="2024-09-03T12:34:56Z")
+
+    assert format_github_run_time(123, info) == "2024-09-03 12:34Z"
+    assert format_github_run_time(123, None) == "#123"
+
+
+def test_fetch_github_run_info_uses_gh_cli() -> None:
+    payload = {
+        "databaseId": 123,
+        "startedAt": "2024-09-03T10:00:00Z",
+        "updatedAt": "2024-09-03T12:34:56Z",
+        "url": "https://example.invalid/run/123",
+        "status": "completed",
+        "conclusion": "failure",
+        "displayTitle": "Extract OTA symbols",
+    }
+
+    with patch("symx.admin.github.subprocess.run") as mock_run:
+        mock_run.return_value.returncode = 0
+        mock_run.return_value.stdout = json.dumps(payload)
+        mock_run.return_value.stderr = ""
+
+        info = fetch_github_run_info(123)
+
+    assert info == GithubRunInfo(
+        run_id=123,
+        started_at="2024-09-03T10:00:00Z",
+        updated_at="2024-09-03T12:34:56Z",
+        url="https://example.invalid/run/123",
+        status="completed",
+        conclusion="failure",
+        display_title="Extract OTA symbols",
+    )
+
+
+def test_ensure_github_run_infos_uses_cache_for_existing_runs(tmp_path: Path) -> None:
+    cached = GithubRunInfo(run_id=123, updated_at="2024-09-03T12:34:56Z")
+    fetched = GithubRunInfo(run_id=456, updated_at="2024-09-04T12:34:56Z")
+    write_github_run_cache(tmp_path, {123: cached})
+
+    with patch("symx.admin.github.fetch_github_run_info", return_value=fetched) as fetch_run_info:
+        result = ensure_github_run_infos(tmp_path, [123, 456])
+
+    fetch_run_info.assert_called_once_with(456)
+    assert result[123] == cached
+    assert result[456] == fetched

--- a/tests/test_admin_remote.py
+++ b/tests/test_admin_remote.py
@@ -1,0 +1,129 @@
+from datetime import date, datetime
+
+from pydantic import HttpUrl
+
+from symx.admin.actions import (
+    AdminActionKind,
+    AdminStore,
+    ApplyBatchRequest,
+    ApplyBatchStatus,
+    IpswTarget,
+    WorkerDispatchResult,
+    WorkerDispatchStatus,
+)
+from symx.admin.remote import execute_apply_request
+from symx.ipsw.model import (
+    IpswArtifact,
+    IpswArtifactDb,
+    IpswArtifactHashes,
+    IpswPlatform,
+    IpswReleaseStatus,
+    IpswSource,
+)
+from symx.model import ArtifactProcessingState
+
+
+class _FakeBlob:
+    def __init__(self, payload: str, generation: int) -> None:
+        self.payload = payload
+        self.generation = generation
+        self.uploads: list[tuple[str, int]] = []
+
+    def reload(self) -> None:
+        return None
+
+    def download_as_text(self) -> str:
+        return self.payload
+
+    def upload_from_string(self, payload: str, if_generation_match: int) -> None:
+        self.uploads.append((payload, if_generation_match))
+        self.payload = payload
+        self.generation += 1
+
+
+class _FakeBucket:
+    def __init__(self, blob: _FakeBlob) -> None:
+        self._blob = blob
+
+    def blob(self, name: str) -> _FakeBlob:
+        return self._blob
+
+
+def _make_ipsw_payload() -> str:
+    ipsw_db = IpswArtifactDb(
+        artifacts={
+            "iOS_18.0_22A100": IpswArtifact(
+                platform=IpswPlatform.IOS,
+                version="18.0",
+                build="22A100",
+                released=date(2024, 9, 1),
+                release_status=IpswReleaseStatus.RELEASE,
+                sources=[
+                    IpswSource(
+                        devices=["iPhone17,1"],
+                        link=HttpUrl("https://updates.cdn-apple.com/test.ipsw"),
+                        hashes=IpswArtifactHashes(sha1="abc", sha2=None),
+                        size=123,
+                        processing_state=ArtifactProcessingState.SYMBOLS_EXTRACTED,
+                        mirror_path="mirror/ipsw/iOS/18.0/22A100/test.ipsw",
+                        last_run=111,
+                        last_modified=datetime(2024, 9, 3, 12, 0, 0),
+                    )
+                ],
+            )
+        }
+    )
+    return ipsw_db.model_dump_json()
+
+
+def test_execute_apply_request_refuses_stale_generation(monkeypatch) -> None:
+    request = ApplyBatchRequest(
+        store=AdminStore.IPSW,
+        action=AdminActionKind.QUEUE_EXTRACT,
+        snapshot_id="ipsw-101__ota-202",
+        base_generation=100,
+        reason="retry extract",
+        targets=(IpswTarget(artifact_key="iOS_18.0_22A100", link="https://updates.cdn-apple.com/test.ipsw"),),
+    )
+    fake_blob = _FakeBlob(_make_ipsw_payload(), generation=101)
+
+    monkeypatch.setattr("symx.admin.remote._bucket_for_storage", lambda storage: _FakeBucket(fake_blob))
+
+    result = execute_apply_request("gs://bucket", request)
+
+    assert result.status == ApplyBatchStatus.STALE_GENERATION
+    assert result.remote_generation == 101
+    assert fake_blob.uploads == []
+
+
+def test_execute_apply_request_returns_worker_warning_after_successful_apply(monkeypatch) -> None:
+    request = ApplyBatchRequest(
+        store=AdminStore.IPSW,
+        action=AdminActionKind.QUEUE_EXTRACT,
+        snapshot_id="ipsw-101__ota-202",
+        base_generation=101,
+        reason="retry extract",
+        targets=(IpswTarget(artifact_key="iOS_18.0_22A100", link="https://updates.cdn-apple.com/test.ipsw"),),
+    )
+    fake_blob = _FakeBlob(_make_ipsw_payload(), generation=101)
+
+    monkeypatch.setattr("symx.admin.remote._bucket_for_storage", lambda storage: _FakeBucket(fake_blob))
+    monkeypatch.setattr(
+        "symx.admin.remote.ensure_worker_running",
+        lambda request, status_callback=None: WorkerDispatchResult(
+            workflow="symx-ipsw-extract.yml",
+            status=WorkerDispatchStatus.DISPATCH_FAILED,
+            detail="gh workflow run failed",
+        ),
+    )
+    monkeypatch.setenv("GITHUB_RUN_ID", "555")
+
+    result = execute_apply_request("gs://bucket", request)
+
+    assert result.status == ApplyBatchStatus.APPLIED_WITH_WORKER_WARNING
+    assert result.applied_count == 1
+    assert fake_blob.uploads[0][1] == 101
+    uploaded_db = IpswArtifactDb.model_validate_json(fake_blob.payload)
+    uploaded_source = uploaded_db.artifacts["iOS_18.0_22A100"].sources[0]
+    assert uploaded_source.processing_state == ArtifactProcessingState.MIRRORED
+    assert uploaded_source.last_run == 555

--- a/tests/test_admin_remote.py
+++ b/tests/test_admin_remote.py
@@ -6,12 +6,13 @@ from symx.admin.actions import (
     AdminActionKind,
     AdminStore,
     ApplyBatchRequest,
+    ApplyBatchResult,
     ApplyBatchStatus,
     IpswTarget,
     WorkerDispatchResult,
     WorkerDispatchStatus,
 )
-from symx.admin.remote import execute_apply_request
+from symx.admin.remote import append_apply_summary, execute_apply_request
 from symx.ipsw.model import (
     IpswArtifact,
     IpswArtifactDb,
@@ -94,6 +95,30 @@ def test_execute_apply_request_refuses_stale_generation(monkeypatch) -> None:
     assert result.status == ApplyBatchStatus.STALE_GENERATION
     assert result.remote_generation == 101
     assert fake_blob.uploads == []
+
+
+def test_append_apply_summary_appends_to_existing_file(tmp_path) -> None:
+    summary_path = tmp_path / "summary.md"
+    summary_path.write_text("existing summary\n")
+    result = ApplyBatchResult(
+        status=ApplyBatchStatus.APPLIED,
+        store=AdminStore.IPSW,
+        action=AdminActionKind.QUEUE_EXTRACT,
+        snapshot_id="ipsw-101__ota-202",
+        base_generation=101,
+        remote_generation=101,
+        targets=(IpswTarget(artifact_key="iOS_18.0_22A100", link="https://updates.cdn-apple.com/test.ipsw"),),
+        reason="retry extract",
+        applied_count=1,
+        message="applied",
+    )
+
+    append_apply_summary(summary_path, result)
+
+    content = summary_path.read_text()
+    assert content.startswith("existing summary\n")
+    assert "# Admin apply: applied" in content
+    assert content.count("# Admin apply: applied") == 1
 
 
 def test_execute_apply_request_returns_worker_warning_after_successful_apply(monkeypatch) -> None:

--- a/tests/test_admin_sync.py
+++ b/tests/test_admin_sync.py
@@ -6,8 +6,10 @@ from pathlib import Path
 
 from pydantic import HttpUrl
 
+import pytest
+
 from symx.admin.db import load_snapshot_info, read_manifest, snapshot_paths
-from symx.admin.sync import ADMIN_META_ARTIFACT, ADMIN_META_SUMMARY, run_sync
+from symx.admin.sync import ADMIN_META_ARTIFACT, ADMIN_META_SUMMARY, AdminSyncError, _coerce_int, run_sync
 from symx.ipsw.model import (
     IpswArtifact,
     IpswArtifactDb,
@@ -271,6 +273,11 @@ def test_run_sync_merges_partial_update_with_latest_local_snapshot(tmp_path: Pat
         "-f",
         "known_ota_generation=202",
     ]
+
+
+def test_sync_coerce_int_rejects_boolean_values(tmp_path: Path) -> None:
+    with pytest.raises(AdminSyncError, match="Unexpected ipsw_generation type"):
+        _coerce_int(True, tmp_path / "summary.json", "ipsw_generation")
 
 
 def test_run_sync_rebuilds_incomplete_snapshot(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_admin_sync.py
+++ b/tests/test_admin_sync.py
@@ -1,0 +1,320 @@
+import json
+import subprocess
+from collections.abc import Callable
+from datetime import date, datetime
+from pathlib import Path
+
+from pydantic import HttpUrl
+
+from symx.admin.db import load_snapshot_info, read_manifest, snapshot_paths
+from symx.admin.sync import ADMIN_META_ARTIFACT, ADMIN_META_SUMMARY, run_sync
+from symx.ipsw.model import (
+    IpswArtifact,
+    IpswArtifactDb,
+    IpswArtifactHashes,
+    IpswPlatform,
+    IpswReleaseStatus,
+    IpswSource,
+)
+from symx.model import ArtifactProcessingState
+from symx.ota.model import OtaArtifact
+
+
+def _sample_ipsw_db() -> IpswArtifactDb:
+    return IpswArtifactDb(
+        artifacts={
+            "iOS_18.0_22A100": IpswArtifact(
+                platform=IpswPlatform.IOS,
+                version="18.0",
+                build="22A100",
+                released=date(2024, 9, 1),
+                release_status=IpswReleaseStatus.RELEASE,
+                sources=[
+                    IpswSource(
+                        devices=["iPhone17,1"],
+                        link=HttpUrl("https://updates.cdn-apple.com/test.ipsw"),
+                        hashes=IpswArtifactHashes(sha1="abc", sha2=None),
+                        size=123,
+                        processing_state=ArtifactProcessingState.SYMBOL_EXTRACTION_FAILED,
+                        last_run=111,
+                        last_modified=datetime(2024, 9, 3, 12, 0, 0),
+                    )
+                ],
+            )
+        }
+    )
+
+
+def _sample_ota_meta(last_run: int = 222, artifact_id: str = "ota-id") -> dict[str, OtaArtifact]:
+    return {
+        "ota-key": OtaArtifact(
+            build="22A100",
+            description=["full"],
+            version="18.0",
+            platform="ios",
+            id=artifact_id,
+            url=f"https://updates.cdn-apple.com/{artifact_id}.zip",
+            download_path=None,
+            devices=["iPhone17,1"],
+            hash="def",
+            hash_algorithm="SHA-1",
+            last_run=last_run,
+            processing_state=ArtifactProcessingState.INDEXED_INVALID,
+        )
+    }
+
+
+def _write_admin_meta_artifact(
+    download_dir: Path,
+    *,
+    ipsw_generation: int,
+    ota_generation: int,
+    ipsw_changed: bool,
+    ota_changed: bool,
+    ipsw_db: IpswArtifactDb | None = None,
+    ota_meta: dict[str, OtaArtifact] | None = None,
+) -> None:
+    download_dir.mkdir(parents=True, exist_ok=True)
+    (download_dir / ADMIN_META_SUMMARY).write_text(
+        json.dumps(
+            {
+                "ipsw_generation": ipsw_generation,
+                "ota_generation": ota_generation,
+                "ipsw_changed": ipsw_changed,
+                "ota_changed": ota_changed,
+            }
+        )
+    )
+    (download_dir / "ipsw_meta_blob.json").write_text(json.dumps({"generation": ipsw_generation}))
+    (download_dir / "ota_image_meta_blob.json").write_text(json.dumps({"generation": ota_generation}))
+    if ipsw_changed:
+        assert ipsw_db is not None
+        (download_dir / "ipsw_meta.json").write_text(ipsw_db.model_dump_json())
+    if ota_changed:
+        assert ota_meta is not None
+        (download_dir / "ota_image_meta.json").write_text(
+            json.dumps({key: value.model_dump() for key, value in ota_meta.items()})
+        )
+
+
+class _FakeGh:
+    def __init__(
+        self,
+        *,
+        artifacts_by_run: dict[int, bool],
+        downloads_by_run: dict[int, Callable[[Path], None]],
+    ) -> None:
+        self.artifacts_by_run = artifacts_by_run
+        self.downloads_by_run = downloads_by_run
+        self.dispatches: list[list[str]] = []
+
+    def __call__(self, args: list[str]) -> subprocess.CompletedProcess[str]:
+        if args[:2] == ["workflow", "run"]:
+            self.dispatches.append(args)
+            return subprocess.CompletedProcess(["gh", *args], 0, "", "")
+
+        if args[:2] == ["api", "repos/{owner}/{repo}/actions/runs/555/artifacts"]:
+            return self._artifact_response(555, args)
+        if args[:2] == ["api", "repos/{owner}/{repo}/actions/runs/556/artifacts"]:
+            return self._artifact_response(556, args)
+        if args[:2] == ["api", "repos/{owner}/{repo}/actions/runs/557/artifacts"]:
+            return self._artifact_response(557, args)
+
+        if args[:2] == ["run", "download"]:
+            run_id = int(args[2])
+            download_dir = Path(args[args.index("--dir") + 1])
+            writer = self.downloads_by_run.get(run_id)
+            if writer is None:
+                raise AssertionError(f"Unexpected download for run {run_id}")
+            writer(download_dir)
+            return subprocess.CompletedProcess(["gh", *args], 0, "", "")
+
+        return subprocess.CompletedProcess(["gh", *args], 0, "", "")
+
+    def _artifact_response(self, run_id: int, args: list[str]) -> subprocess.CompletedProcess[str]:
+        artifacts = []
+        if self.artifacts_by_run.get(run_id, False):
+            artifacts.append({"name": ADMIN_META_ARTIFACT})
+        return subprocess.CompletedProcess(["gh", *args], 0, json.dumps({"artifacts": artifacts}), "")
+
+
+def test_run_sync_creates_snapshot_then_short_circuits_when_unchanged(tmp_path: Path, monkeypatch) -> None:
+    ipsw_db = _sample_ipsw_db()
+    ota_meta = _sample_ota_meta()
+    fake_gh = _FakeGh(
+        artifacts_by_run={555: True, 556: False},
+        downloads_by_run={
+            555: lambda download_dir: _write_admin_meta_artifact(
+                download_dir,
+                ipsw_generation=101,
+                ota_generation=202,
+                ipsw_changed=True,
+                ota_changed=True,
+                ipsw_db=ipsw_db,
+                ota_meta=ota_meta,
+            )
+        },
+    )
+
+    monkeypatch.setattr("symx.admin.sync._list_workflow_runs", lambda workflow, limit: [])
+    monkeypatch.setattr("symx.admin.sync._run_gh_command", fake_gh)
+    monkeypatch.setattr(
+        "symx.admin.sync._wait_for_new_run",
+        lambda workflow, before_max_run_id: {
+            "databaseId": 555 if not fake_gh.dispatches or len(fake_gh.dispatches) == 1 else 556,
+            "url": "https://example.invalid/run/555",
+        },
+    )
+    monkeypatch.setattr(
+        "symx.admin.sync._wait_for_run_completion",
+        lambda workflow, run_id, status_callback: {
+            "databaseId": run_id,
+            "url": f"https://example.invalid/run/{run_id}",
+            "status": "completed",
+            "conclusion": "success",
+        },
+    )
+
+    messages: list[str] = []
+    first = run_sync(tmp_path, status_callback=messages.append)
+    second = run_sync(tmp_path, status_callback=messages.append)
+
+    assert first.snapshot_id == "ipsw-101__ota-202"
+    assert first.is_new_snapshot is True
+    assert second.snapshot_id == first.snapshot_id
+    assert second.is_new_snapshot is False
+
+    manifest = read_manifest(tmp_path)
+    assert manifest.active_snapshot_id == first.snapshot_id
+
+    info = load_snapshot_info(snapshot_paths(tmp_path, first.snapshot_id).db_path)
+    assert info is not None
+    assert info.workflow_run_id == 555
+    assert info.ipsw_generation == 101
+    assert info.ota_generation == 202
+    assert any("No download was needed." in message for message in messages)
+    assert fake_gh.dispatches[1] == [
+        "workflow",
+        "run",
+        "symx-admin-meta-sync.yml",
+        "-f",
+        "known_ipsw_generation=101",
+        "-f",
+        "known_ota_generation=202",
+    ]
+
+
+def test_run_sync_merges_partial_update_with_latest_local_snapshot(tmp_path: Path, monkeypatch) -> None:
+    ipsw_db = _sample_ipsw_db()
+    ota_meta_v1 = _sample_ota_meta(last_run=222, artifact_id="ota-id-v1")
+    ota_meta_v2 = _sample_ota_meta(last_run=333, artifact_id="ota-id-v2")
+    fake_gh = _FakeGh(
+        artifacts_by_run={555: True, 556: True},
+        downloads_by_run={
+            555: lambda download_dir: _write_admin_meta_artifact(
+                download_dir,
+                ipsw_generation=101,
+                ota_generation=202,
+                ipsw_changed=True,
+                ota_changed=True,
+                ipsw_db=ipsw_db,
+                ota_meta=ota_meta_v1,
+            ),
+            556: lambda download_dir: _write_admin_meta_artifact(
+                download_dir,
+                ipsw_generation=101,
+                ota_generation=303,
+                ipsw_changed=False,
+                ota_changed=True,
+                ota_meta=ota_meta_v2,
+            ),
+        },
+    )
+
+    monkeypatch.setattr("symx.admin.sync._list_workflow_runs", lambda workflow, limit: [])
+    monkeypatch.setattr("symx.admin.sync._run_gh_command", fake_gh)
+    next_run_ids = iter([555, 556])
+    monkeypatch.setattr(
+        "symx.admin.sync._wait_for_new_run",
+        lambda workflow, before_max_run_id: {
+            "databaseId": next(next_run_ids),
+            "url": "https://example.invalid/run",
+        },
+    )
+    monkeypatch.setattr(
+        "symx.admin.sync._wait_for_run_completion",
+        lambda workflow, run_id, status_callback: {
+            "databaseId": run_id,
+            "url": f"https://example.invalid/run/{run_id}",
+            "status": "completed",
+            "conclusion": "success",
+        },
+    )
+
+    first = run_sync(tmp_path)
+    second = run_sync(tmp_path)
+
+    assert first.snapshot_id == "ipsw-101__ota-202"
+    assert second.snapshot_id == "ipsw-101__ota-303"
+    assert second.is_new_snapshot is True
+
+    info = load_snapshot_info(snapshot_paths(tmp_path, second.snapshot_id).db_path)
+    assert info is not None
+    assert info.ipsw_generation == 101
+    assert info.ota_generation == 303
+    assert fake_gh.dispatches[1] == [
+        "workflow",
+        "run",
+        "symx-admin-meta-sync.yml",
+        "-f",
+        "known_ipsw_generation=101",
+        "-f",
+        "known_ota_generation=202",
+    ]
+
+
+def test_run_sync_rebuilds_incomplete_snapshot(tmp_path: Path, monkeypatch) -> None:
+    ipsw_db = _sample_ipsw_db()
+    ota_meta = _sample_ota_meta()
+    incomplete_paths = snapshot_paths(tmp_path, "ipsw-101__ota-202")
+    incomplete_paths.root.mkdir(parents=True, exist_ok=True)
+    incomplete_paths.db_path.write_text("")
+
+    fake_gh = _FakeGh(
+        artifacts_by_run={557: True},
+        downloads_by_run={
+            557: lambda download_dir: _write_admin_meta_artifact(
+                download_dir,
+                ipsw_generation=101,
+                ota_generation=202,
+                ipsw_changed=True,
+                ota_changed=True,
+                ipsw_db=ipsw_db,
+                ota_meta=ota_meta,
+            )
+        },
+    )
+
+    monkeypatch.setattr("symx.admin.sync._list_workflow_runs", lambda workflow, limit: [])
+    monkeypatch.setattr("symx.admin.sync._run_gh_command", fake_gh)
+    monkeypatch.setattr(
+        "symx.admin.sync._wait_for_new_run",
+        lambda workflow, before_max_run_id: {"databaseId": 557, "url": "https://example.invalid/run/557"},
+    )
+    monkeypatch.setattr(
+        "symx.admin.sync._wait_for_run_completion",
+        lambda workflow, run_id, status_callback: {
+            "databaseId": 557,
+            "url": "https://example.invalid/run/557",
+            "status": "completed",
+            "conclusion": "success",
+        },
+    )
+
+    result = run_sync(tmp_path)
+
+    assert result.snapshot_id == "ipsw-101__ota-202"
+    assert result.is_new_snapshot is True
+    info = load_snapshot_info(incomplete_paths.db_path)
+    assert info is not None
+    assert info.ipsw_generation == 101

--- a/tests/test_admin_tui.py
+++ b/tests/test_admin_tui.py
@@ -1,10 +1,14 @@
+import threading
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 
 from rich.text import Text
 
 from symx.admin.github import GithubRunInfo
 from symx.admin.tui import (
+    AdminTui,
     BackgroundTaskEntry,
+    DownloadQueueItem,
     format_failure_table_title,
     format_ipsw_detail,
     format_ota_detail,
@@ -85,6 +89,40 @@ def test_task_formatting_shows_short_row_text_and_full_details() -> None:
     assert task.result_detail is not None
     assert task.result_detail in detail
     assert format_failure_table_title("IPSW failures", 12) == "IPSW failures (12)"
+
+
+def test_download_worker_idle_check_avoids_clearing_active_queue(tmp_path: Path) -> None:
+    app = AdminTui(cache_dir=tmp_path)
+    current = threading.current_thread()
+
+    app._download_worker_thread = current
+    assert app._finish_download_worker_if_idle() is True
+    assert app._download_worker_thread is None
+
+    app._download_queue.put(
+        DownloadQueueItem(
+            task_id="task-1",
+            item_label="test.ipsw",
+            row=IpswFailureRow(
+                last_modified="2024-09-03T12:34:56",
+                processing_state=ArtifactProcessingState.SYMBOL_EXTRACTION_FAILED,
+                platform="iOS",
+                version="18.0",
+                build="22A100",
+                artifact_key="iOS_18.0_22A100",
+                file_name="test.ipsw",
+                link="https://updates.cdn-apple.com/test.ipsw",
+                sha1="abc123",
+                last_run=123,
+                mirror_path=None,
+            ),
+        )
+    )
+    app._download_worker_thread = current
+    assert app._finish_download_worker_if_idle() is False
+    assert app._download_worker_thread is current
+    app._download_queue.get_nowait()
+    app._download_queue.task_done()
 
 
 def test_format_ota_detail_includes_resolved_run_time() -> None:

--- a/tests/test_admin_tui.py
+++ b/tests/test_admin_tui.py
@@ -1,0 +1,117 @@
+from datetime import UTC, datetime, timedelta
+
+from rich.text import Text
+
+from symx.admin.github import GithubRunInfo
+from symx.admin.tui import (
+    BackgroundTaskEntry,
+    format_failure_table_title,
+    format_ipsw_detail,
+    format_ota_detail,
+    format_task_detail,
+    format_task_status,
+    should_auto_sync_on_start,
+    summarize_task_detail,
+)
+from symx.admin.db import IpswFailureRow, OtaFailureRow, SnapshotInfo
+from symx.model import ArtifactProcessingState
+
+
+def test_format_ipsw_detail_contains_key_fields() -> None:
+    row = IpswFailureRow(
+        last_modified="2024-09-03T12:34:56",
+        processing_state=ArtifactProcessingState.SYMBOL_EXTRACTION_FAILED,
+        platform="iOS",
+        version="18.0",
+        build="22A100",
+        artifact_key="iOS_18.0_22A100",
+        file_name="test.ipsw",
+        link="https://updates.cdn-apple.com/test.ipsw",
+        sha1="abc123",
+        last_run=123,
+        mirror_path=None,
+    )
+
+    detail = format_ipsw_detail(row)
+
+    assert "type: IPSW source" in detail
+    assert "state: symbol_extraction_failed" in detail
+    assert "last_run: #123" in detail
+    assert "file_name: test.ipsw" in detail
+
+
+def test_should_auto_sync_on_start_for_missing_stale_and_fresh_snapshots() -> None:
+    now = datetime(2024, 9, 4, 12, 0, 0, tzinfo=UTC)
+    stale_snapshot = SnapshotInfo(
+        snapshot_id="ipsw-1__ota-2",
+        created_at=(now - timedelta(hours=25)).isoformat(),
+        workflow_run_id=1,
+        workflow_run_url=None,
+        ipsw_generation=1,
+        ota_generation=2,
+    )
+    fresh_snapshot = SnapshotInfo(
+        snapshot_id="ipsw-3__ota-4",
+        created_at=(now - timedelta(hours=23)).isoformat(),
+        workflow_run_id=2,
+        workflow_run_url=None,
+        ipsw_generation=3,
+        ota_generation=4,
+    )
+
+    assert should_auto_sync_on_start(None, now=now) is True
+    assert should_auto_sync_on_start(stale_snapshot, now=now) is True
+    assert should_auto_sync_on_start(fresh_snapshot, now=now) is False
+
+
+def test_task_formatting_shows_short_row_text_and_full_details() -> None:
+    task = BackgroundTaskEntry(
+        task_id="task-1",
+        kind="download",
+        status="warning",
+        item="ota-id",
+        progress_detail="Downloaded 2048MiB",
+        result_detail="Downloaded without SHA verification (unsupported hash algorithm SHA-256): /tmp/very/long/path.zip",
+    )
+
+    status = format_task_status(task.status)
+    detail = format_task_detail(task)
+
+    assert isinstance(status, Text)
+    assert status.plain == "! warning"
+    assert summarize_task_detail(task, max_length=32).endswith("…")
+    assert "type: Background task" in detail
+    assert task.progress_detail in detail
+    assert task.result_detail is not None
+    assert task.result_detail in detail
+    assert format_failure_table_title("IPSW failures", 12) == "IPSW failures (12)"
+
+
+def test_format_ota_detail_includes_resolved_run_time() -> None:
+    row = OtaFailureRow(
+        last_run=456,
+        processing_state=ArtifactProcessingState.INDEXED_INVALID,
+        platform="ios",
+        version="18.0",
+        build="22A100",
+        ota_key="ota-key",
+        artifact_id="ota-id",
+        url="https://updates.cdn-apple.com/test.zip",
+        hash="def456",
+        hash_algorithm="SHA-1",
+        download_path=None,
+    )
+    run_info = GithubRunInfo(
+        run_id=456,
+        started_at="2024-09-03T10:00:00Z",
+        updated_at="2024-09-03T12:34:56Z",
+        url="https://example.invalid/run/456",
+        display_title="Extract OTA symbols",
+    )
+
+    detail = format_ota_detail(row, run_info)
+
+    assert "type: OTA artifact" in detail
+    assert "last_run: #456" in detail
+    assert "last_run_at: 2024-09-03 12:34Z" in detail
+    assert "run_title: Extract OTA symbols" in detail

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -49,6 +49,17 @@ def test_download_url_to_file_without_content_length(tmp_path: Path) -> None:
     assert filepath.read_bytes() == b"data"
 
 
+def test_download_url_to_file_reports_status_via_callback(tmp_path: Path) -> None:
+    filepath = tmp_path / "out.bin"
+    messages: list[str] = []
+
+    with patch("symx.download.requests.get", return_value=_fake_response([b"data"], content_length="4")):
+        download_url_to_file("https://example.com/file", filepath, status_callback=messages.append)
+
+    assert any("Filesize:" in message for message in messages)
+    assert any("Downloaded" in message for message in messages)
+
+
 def test_download_url_to_file_raises_on_http_error(tmp_path: Path) -> None:
     """A 404/500 response must raise, otherwise the error body is silently written to disk."""
     filepath = tmp_path / "out.bin"
@@ -76,7 +87,7 @@ def test_try_download_retries_then_succeeds(tmp_path: Path) -> None:
     filepath = tmp_path / "out.bin"
     call_count = 0
 
-    def flaky(url: str, filepath: Path) -> None:
+    def flaky(url: str, filepath: Path, status_callback: object = None) -> None:
         nonlocal call_count
         call_count += 1
         if call_count < 3:
@@ -95,7 +106,7 @@ def test_try_download_retries_on_http_error(tmp_path: Path) -> None:
     filepath = tmp_path / "out.bin"
     attempts = 0
 
-    def flaky(url: str, filepath: Path) -> None:
+    def flaky(url: str, filepath: Path, status_callback: object = None) -> None:
         nonlocal attempts
         attempts += 1
         if attempts < 2:
@@ -106,6 +117,25 @@ def test_try_download_retries_on_http_error(tmp_path: Path) -> None:
         try_download_url_to_file("https://example.com/flaky", filepath, num_retries=5)
 
     assert attempts == 2
+    assert filepath.read_bytes() == b"ok"
+
+
+def test_try_download_reports_retry_status_via_callback(tmp_path: Path) -> None:
+    filepath = tmp_path / "out.bin"
+    messages: list[str] = []
+    attempts = 0
+
+    def flaky(url: str, filepath: Path, status_callback: object = None) -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts < 2:
+            raise ConnectionError("transient")
+        filepath.write_bytes(b"ok")
+
+    with patch("symx.download.download_url_to_file", side_effect=flaky):
+        try_download_url_to_file("https://example.com/file", filepath, num_retries=2, status_callback=messages.append)
+
+    assert any("retrying" in message for message in messages)
     assert filepath.read_bytes() == b"ok"
 
 

--- a/tests/test_extract_utils.py
+++ b/tests/test_extract_utils.py
@@ -12,7 +12,13 @@ import pytest
 
 from symx.model import Arch
 from symx.ipsw.model import IpswPlatform
-from symx.ipsw.extract import _map_platform_to_prefix, find_extraction_dir, generate_bundle_id
+from symx.ipsw.extract import (
+    IpswExtractError,
+    IpswExtractor,
+    map_platform_to_prefix,
+    find_extraction_dir,
+    generate_bundle_id,
+)
 from subprocess import CompletedProcess
 
 from symx.ota.model import DSCSearchResult, OtaExtractError
@@ -30,13 +36,13 @@ from symx.ota.extract import (
 
 def test_map_platform_ipados_to_ios() -> None:
     """iPadOS and iOS share the same symbol prefix."""
-    assert _map_platform_to_prefix(IpswPlatform.IPADOS) == "ios"
+    assert map_platform_to_prefix(IpswPlatform.IPADOS) == "ios"
 
 
 def test_map_platform_all_lowercase() -> None:
     """All platform prefixes should be lowercase."""
     for platform in IpswPlatform:
-        prefix = _map_platform_to_prefix(platform)
+        prefix = map_platform_to_prefix(platform)
         assert prefix == prefix.lower()
 
 
@@ -89,6 +95,99 @@ def test_find_extraction_dir_returns_first_match() -> None:
         result = find_extraction_dir(processing_dir)
 
         assert result in [processing_dir / "dir1", processing_dir / "dir2"]
+
+
+# --- IPSW diagnostics tests ---
+
+
+def _make_ipsw_extractor(tmp_path: Path) -> IpswExtractor:
+    processing_dir = tmp_path / "processing"
+    processing_dir.mkdir()
+    ipsw_path = tmp_path / "test.ipsw"
+    ipsw_path.touch()
+    return IpswExtractor(IpswPlatform.IPADOS, "iPad15,7_26.4.2_23E261_Restore.ipsw", processing_dir, ipsw_path)
+
+
+def test_ipsw_extract_dsc_raises_detailed_error_when_extract_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    extractor = _make_ipsw_extractor(tmp_path)
+
+    class FakePopen:
+        def __init__(self, command: list[str], stdout: object = None, stderr: object = None) -> None:
+            self.command = command
+            self.returncode = 1
+
+        def __enter__(self) -> "FakePopen":
+            return self
+
+        def __exit__(self, exc_type: object, exc: object, tb: object) -> bool:
+            return False
+
+        def communicate(self, timeout: int | None = None) -> tuple[bytes, bytes]:
+            return b"extract stdout", b"extract stderr"
+
+        def kill(self) -> None:
+            self.returncode = -9
+
+    monkeypatch.setattr("symx.ipsw.extract.subprocess.Popen", FakePopen)
+
+    with pytest.raises(IpswExtractError, match="ipsw extract failed") as exc_info:
+        extractor._ipsw_extract_dsc()
+
+    message = str(exc_info.value)
+    assert "extract stdout" in message
+    assert "extract stderr" in message
+    assert "command: ipsw extract" in message
+    assert str(extractor.processing_dir) in message
+
+
+def test_ipsw_split_raises_detailed_error_when_split_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    extractor = _make_ipsw_extractor(tmp_path)
+    extract_dir = extractor.processing_dir / "23E261__iPad15,7"
+    extract_dir.mkdir()
+    (extract_dir / "dyld_shared_cache_arm64e").touch()
+
+    def fake_dyld_split(dsc: Path, output_dir: Path) -> CompletedProcess[bytes]:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        (output_dir / "partial").touch()
+        return CompletedProcess(args=[], returncode=1, stdout=b"split stdout", stderr=b"split stderr")
+
+    monkeypatch.setattr("symx.ipsw.extract.dyld_split", fake_dyld_split)
+
+    with pytest.raises(IpswExtractError, match="ipsw dyld split failed") as exc_info:
+        extractor._ipsw_split(extract_dir)
+
+    message = str(exc_info.value)
+    assert "split stdout" in message
+    assert "split stderr" in message
+    assert str(extract_dir) in message
+    assert "split_out" in message
+
+
+def test_ipsw_symsort_raises_detailed_error_when_symsorter_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    extractor = _make_ipsw_extractor(tmp_path)
+    split_dir = extractor.processing_dir / "split_out"
+    split_dir.mkdir()
+    (split_dir / "binary").touch()
+
+    def fake_symsort(
+        output_dir: Path, prefix: str, bundle_id: str, split_dir: Path, ignore_errors: bool = False
+    ) -> CompletedProcess[bytes]:
+        return CompletedProcess(args=[], returncode=1, stdout=b"symsort stdout", stderr=b"symsort stderr")
+
+    monkeypatch.setattr("symx.ipsw.extract.symsort", fake_symsort)
+
+    with pytest.raises(IpswExtractError, match="Symsorter failed for bundle") as exc_info:
+        extractor._symsort(split_dir)
+
+    message = str(exc_info.value)
+    assert "symsort stdout" in message
+    assert "symsort stderr" in message
+    assert str(split_dir) in message
+    assert str(extractor.symbols_dir()) in message
 
 
 # --- parse_cryptex_patch_output tests ---

--- a/uv.lock
+++ b/uv.lock
@@ -220,6 +220,18 @@ wheels = [
 ]
 
 [[package]]
+name = "linkify-it-py"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "uc-micro-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/c9/06ea13676ef354f0af6169587ae292d3e2406e212876a413bf9eece4eb23/linkify_it_py-2.1.0.tar.gz", hash = "sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b", size = 29158, upload-time = "2026-03-01T07:48:47.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl", hash = "sha256:0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e", size = 19878, upload-time = "2026-03-01T07:48:46.098Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -229,6 +241,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528, upload-time = "2023-06-03T06:41:11.019Z" },
+]
+
+[package.optional-dependencies]
+linkify = [
+    { name = "linkify-it-py" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/fd/a756d36c0bfba5f6e39a1cdbdbfdd448dc02692467d83816dff4592a1ebc/mdit_py_plugins-0.5.0.tar.gz", hash = "sha256:f4918cb50119f50446560513a8e311d574ff6aaed72606ddae6d35716fe809c6", size = 44655, upload-time = "2025-08-11T07:25:49.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl", hash = "sha256:07a08422fc1936a5d26d146759e9155ea466e842f5ab2f7d2266dd084c8dab1f", size = 57205, upload-time = "2025-08-11T07:25:47.597Z" },
 ]
 
 [[package]]
@@ -323,6 +352,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6d/02/c6e04b694ffd68568297abd03588b6d30295265176a5c01b7459d3bc35a3/pandas-3.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:15860b1fdb1973fffade772fdb931ccf9b2f400a3f5665aef94a00445d7d8dd5", size = 11810974, upload-time = "2026-02-17T22:20:08.946Z" },
     { url = "https://files.pythonhosted.org/packages/89/41/d7dfb63d2407f12055215070c42fc6ac41b66e90a2946cdc5e759058398b/pandas-3.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:44f1364411d5670efa692b146c748f4ed013df91ee91e9bec5677fb1fd58b937", size = 10884622, upload-time = "2026-02-17T22:20:11.711Z" },
     { url = "https://files.pythonhosted.org/packages/68/b0/34937815889fa982613775e4b97fddd13250f11012d769949c5465af2150/pandas-3.0.1-cp314-cp314t-win_arm64.whl", hash = "sha256:108dd1790337a494aa80e38def654ca3f0968cf4f362c85f44c15e471667102d", size = 9452085, upload-time = "2026-02-17T22:20:14.331Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
 ]
 
 [[package]]
@@ -517,15 +555,15 @@ wheels = [
 
 [[package]]
 name = "rich"
-version = "13.9.4"
+version = "15.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ab/3a/0316b28d0761c6734d6bc14e770d85506c986c85ffb239e688eeaab2c2bc/rich-13.9.4.tar.gz", hash = "sha256:439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098", size = 223149, upload-time = "2024-11-01T16:43:57.873Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/71/39c7c0d87f8d4e6c020a393182060eaefeeae6c01dab6a84ec346f2567df/rich-13.9.4-py3-none-any.whl", hash = "sha256:6049d5e6ec054bf2779ab3358186963bac2ea89175919d699e378b99738c2a90", size = 242424, upload-time = "2024-11-01T16:43:55.817Z" },
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
 ]
 
 [[package]]
@@ -607,6 +645,7 @@ dependencies = [
     { name = "protobuf" },
     { name = "pydantic" },
     { name = "sentry-sdk" },
+    { name = "textual" },
     { name = "typer" },
 ]
 
@@ -626,6 +665,7 @@ requires-dist = [
     { name = "protobuf", specifier = "==6.33.5" },
     { name = "pydantic", specifier = "==2.12.5" },
     { name = "sentry-sdk", specifier = ">=2.54.0" },
+    { name = "textual", specifier = ">=8.2.4" },
     { name = "typer", specifier = "==0.21.1" },
 ]
 
@@ -635,6 +675,23 @@ dev = [
     { name = "pytest", specifier = "==9.0.3" },
     { name = "pytest-cov", specifier = "==7.1.0" },
     { name = "ruff", specifier = "==0.15.7" },
+]
+
+[[package]]
+name = "textual"
+version = "8.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py", extra = ["linkify"] },
+    { name = "mdit-py-plugins" },
+    { name = "platformdirs" },
+    { name = "pygments" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/89/bec5709fb759f9c784bbcb30b2e3497df3f901691d13c2b864dbf6694a17/textual-8.2.4.tar.gz", hash = "sha256:d4e2b2ddd7157191d00b228592b7c739ea080b7d792fd410f23ca75f05ea76c4", size = 1848933, upload-time = "2026-04-19T04:20:45.845Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/32/02932f0d597cdbb34e34bf24266ff0f2cf292ccb3aafc37dd9efcb0cc416/textual-8.2.4-py3-none-any.whl", hash = "sha256:a83bd3f0cc7125ca203845af753f9d6b6be030025ecd1b05cc75ebe645b9c4ba", size = 724390, upload-time = "2026-04-19T04:20:49.968Z" },
 ]
 
 [[package]]
@@ -680,6 +737,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e1/34/943888654477a574a86a98e9896bae89c7aa15078ec29f490fef2f1e5384/tzdata-2024.2.tar.gz", hash = "sha256:7d85cc416e9382e69095b7bdf4afd9e3880418a2413feec7069d533d6b4e31cc", size = 193282, upload-time = "2024-09-23T18:56:46.89Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a6/ab/7e5f53c3b9d14972843a647d8d7a853969a58aecc7559cb3267302c94774/tzdata-2024.2-py2.py3-none-any.whl", hash = "sha256:a48093786cdcde33cad18c2555e8532f34422074448fbc874186f0abd79565cd", size = 346586, upload-time = "2024-09-23T18:56:45.478Z" },
+]
+
+[[package]]
+name = "uc-micro-py"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/67/9a363818028526e2d4579334460df777115bdec1bb77c08f9db88f6389f2/uc_micro_py-2.0.0.tar.gz", hash = "sha256:c53691e495c8db60e16ffc4861a35469b0ba0821fe409a8a7a0a71864d33a811", size = 6611, upload-time = "2026-03-01T06:31:27.526Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl", hash = "sha256:3603a3859af53e5a39bc7677713c78ea6589ff188d70f4fee165db88e22b242c", size = 6383, upload-time = "2026-03-01T06:31:26.257Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This is work I did on/off over the last 2 months, and now I have reached a sufficiently useful shape. The admin TUI helps with the day-to-day ops topics, which currently is split across, sentry, github and the meta-data storage which is only indirectly accessible from GHA workflow runs:

- refresh and cache production meta locally
- browse IPSW sources and OTA artifacts
- resolve GitHub run context for rows so I don't have to do it manually
- download selected artifacts locally so local investigation can happen
- queue curated reruns from the TUI (local data is otherwise immutable, no generic metadata editing should be allowed for now, thus curated, i.e., particular use cases will be integrated and handle the transactional boundary)
- apply rerun batches safely via GHA (matching generation + local auto-refresh and retry)

It is still a little rough around the edges, but already useful and correctly applying the bounds across the runner env (currently runs only via GHA workflows; implemented in a way that allows running against a locally accessible GCS).

It already implements a significant part of #44.

<img width="1374" height="1045" alt="image" src="https://github.com/user-attachments/assets/cc00518c-3415-4d3e-a94d-d8b979107fa8" />
