### PR TITLE
fix: improve extraction diagnostics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ ipsw_meta*.json
 ota_image_meta*.json
 *.ipsw
 *.zip
+*.aea

--- a/symx/admin/actions.py
+++ b/symx/admin/actions.py
@@ -265,6 +265,7 @@ def _excluded_states(store: AdminStore) -> frozenset[ArtifactProcessingState]:
             ArtifactProcessingState.INDEXED_DUPLICATE,
             ArtifactProcessingState.DELTA_OTA,
             ArtifactProcessingState.RECOVERY_OTA,
+            ArtifactProcessingState.UNSUPPORTED_OTA_PAYLOAD,
         }
     )
 

--- a/symx/admin/tui.py
+++ b/symx/admin/tui.py
@@ -856,7 +856,9 @@ class AdminTui(App[None]):
                     result = _download_selected_item(
                         item.row,
                         self.cache_dir,
-                        status_callback=lambda message: self._download_progress_from_thread(item.task_id, message),
+                        status_callback=lambda message, tid=item.task_id: self._download_progress_from_thread(
+                            tid, message
+                        ),
                     )
                 except Exception as exc:
                     self._task_update_from_thread(item.task_id, status="failed", result_detail=str(exc))

--- a/symx/diagnostics.py
+++ b/symx/diagnostics.py
@@ -4,6 +4,7 @@ import shlex
 import subprocess
 from collections.abc import Sequence
 from pathlib import Path
+from typing import cast
 
 MAX_SUBPROCESS_OUTPUT_CHARS = 4_000
 DEFAULT_DIRECTORY_SAMPLE_ENTRIES = 20
@@ -17,22 +18,43 @@ def decode_subprocess_output(output: str | bytes | None) -> str:
     return output
 
 
+def truncate_text(output: str | bytes | None, max_chars: int = MAX_SUBPROCESS_OUTPUT_CHARS) -> str | None:
+    text = decode_subprocess_output(output).strip()
+    if not text:
+        return None
+
+    if len(text) > max_chars:
+        omitted = len(text) - max_chars
+        text = f"{text[:max_chars]}\n... [truncated {omitted} chars]"
+    return text
+
+
 def format_subprocess_output(
     label: str,
     output: str | bytes | None,
     max_chars: int = MAX_SUBPROCESS_OUTPUT_CHARS,
     indent: str = "    ",
 ) -> str:
-    text = decode_subprocess_output(output).strip()
-    if not text:
+    text = truncate_text(output, max_chars=max_chars)
+    if text is None:
         return f"  {label}: <empty>"
-
-    if len(text) > max_chars:
-        omitted = len(text) - max_chars
-        text = f"{text[:max_chars]}\n... [truncated {omitted} chars]"
 
     indented = "\n".join(f"{indent}{line}" for line in text.splitlines())
     return f"  {label}:\n{indented}"
+
+
+def subprocess_result_data(
+    result: subprocess.CompletedProcess[bytes] | subprocess.CompletedProcess[str] | None,
+) -> dict[str, object]:
+    if result is None:
+        return {"attempted": False}
+
+    return {
+        "attempted": True,
+        "returncode": result.returncode,
+        "stdout": truncate_text(result.stdout),
+        "stderr": truncate_text(result.stderr),
+    }
 
 
 def format_subprocess_result(
@@ -55,24 +77,44 @@ def format_command(command: Sequence[str]) -> str:
     return " ".join(shlex.quote(part) for part in command)
 
 
-def describe_directory(directory: Path, max_entries: int = DEFAULT_DIRECTORY_SAMPLE_ENTRIES, indent: str = "  ") -> str:
-    if not directory.exists():
-        return f"directory {directory}: <missing>"
-    if not directory.is_dir():
-        return f"directory {directory}: <not a directory>"
+def directory_data(directory: Path, max_entries: int = DEFAULT_DIRECTORY_SAMPLE_ENTRIES) -> dict[str, object]:
+    data: dict[str, object] = {
+        "path": str(directory),
+        "exists": directory.exists(),
+        "is_dir": directory.is_dir(),
+    }
+    if not directory.exists() or not directory.is_dir():
+        return data
 
     sample_entries: list[str] = []
+    truncated = False
     for path in directory.rglob("*"):
         suffix = "/" if path.is_dir() else ""
         sample_entries.append(f"{path.relative_to(directory)}{suffix}")
         if len(sample_entries) >= max_entries:
+            truncated = True
             break
 
-    if not sample_entries:
+    data["sample_entries"] = sample_entries
+    data["sample_truncated"] = truncated
+    return data
+
+
+def describe_directory(directory: Path, max_entries: int = DEFAULT_DIRECTORY_SAMPLE_ENTRIES, indent: str = "  ") -> str:
+    data = directory_data(directory, max_entries=max_entries)
+    if not data["exists"]:
+        return f"directory {directory}: <missing>"
+    if not data["is_dir"]:
+        return f"directory {directory}: <not a directory>"
+
+    sample_entries_obj = data.get("sample_entries")
+    if not isinstance(sample_entries_obj, list) or not sample_entries_obj:
         return f"directory {directory}: (empty)"
 
+    sample_entries_raw = cast(list[object], sample_entries_obj)
+    sample_entries = [str(entry) for entry in sample_entries_raw]
     lines = [f"directory {directory} sample entries:"]
     lines.extend(f"{indent}{entry}" for entry in sample_entries)
-    if len(sample_entries) >= max_entries:
+    if data.get("sample_truncated"):
         lines.append(f"{indent}... showing first {max_entries} entries")
     return "\n".join(lines)

--- a/symx/ipsw/extract.py
+++ b/symx/ipsw/extract.py
@@ -7,7 +7,7 @@ import logging
 
 import sentry_sdk
 
-from symx.diagnostics import describe_directory, format_command, format_subprocess_output, format_subprocess_result
+from symx.diagnostics import directory_data, format_command, subprocess_result_data, truncate_text
 from symx.model import Arch
 from symx.tools import dyld_split, symsort
 from symx.ipsw.model import IpswPlatform
@@ -17,21 +17,18 @@ logger = logging.getLogger(__name__)
 mount_point_re = re.compile(r".*Press Ctrl\+C to unmount '(.*)'")
 
 
-def _format_ipsw_command_error(
-    reason: str,
+def _ipsw_command_data(
     command: list[str],
     stdout: str | bytes | None,
     stderr: str | bytes | None,
     directories: list[Path],
-) -> str:
-    details = [
-        reason,
-        f"command: {format_command(command)}",
-        format_subprocess_output("stdout", stdout),
-        format_subprocess_output("stderr", stderr),
-    ]
-    details.extend(describe_directory(directory) for directory in directories)
-    return "\n".join(details)
+) -> dict[str, object]:
+    return {
+        "command": format_command(command),
+        "stdout": truncate_text(stdout),
+        "stderr": truncate_text(stderr),
+        "directories": [directory_data(directory) for directory in directories],
+    }
 
 
 def _compress_directory(directory: Path) -> Path:
@@ -135,6 +132,8 @@ class IpswExtractor:
                 command.append("-a")
                 command.append(str(arch))
 
+            stdout: bytes | None = None
+            stderr: bytes | None = None
             with subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE) as process:
                 try:
                     # IPSW extraction is typically finished in a couple of minutes. Everything beyond 20 minutes is probably
@@ -143,43 +142,27 @@ class IpswExtractor:
                 except subprocess.TimeoutExpired:
                     process.kill()
                     stdout, stderr = process.communicate()
+                    span.set_data("ipsw_extract", _ipsw_command_data(command, stdout, stderr, [self.processing_dir]))
                     span.set_status("deadline_exceeded")
-                    raise IpswExtractError(
-                        _format_ipsw_command_error(
-                            f"ipsw extract timed out after 1200s for {self.ipsw_path} ({arch_label})",
-                            command,
-                            stdout,
-                            stderr,
-                            [self.processing_dir],
-                        )
-                    )
+                    raise IpswExtractTimeoutError(f"ipsw extract timed out for {self.ipsw_path} ({arch_label})")
 
+                span.set_data("ipsw_extract", _ipsw_command_data(command, stdout, stderr, [self.processing_dir]))
                 if process.returncode != 0:
                     span.set_status("internal_error")
                     raise IpswExtractError(
-                        _format_ipsw_command_error(
-                            f"ipsw extract failed for {self.ipsw_path} ({arch_label}) with exit code {process.returncode}",
-                            command,
-                            stdout,
-                            stderr,
-                            [self.processing_dir],
-                        )
+                        f"ipsw extract failed for {self.ipsw_path} ({arch_label}) with exit code {process.returncode}"
                     )
 
             _log_directory_contents(self.processing_dir)
             extract_dir = find_extraction_dir(self.processing_dir)
             if extract_dir is None:
+                span.set_data("processing_dir", directory_data(self.processing_dir))
                 span.set_status("internal_error")
                 raise IpswExtractError(
-                    _format_ipsw_command_error(
-                        f"ipsw extract produced no dyld_shared_cache extraction directory for {self.ipsw_path} ({arch_label})",
-                        command,
-                        stdout,
-                        stderr,
-                        [self.processing_dir],
-                    )
+                    f"ipsw extract produced no dyld_shared_cache extraction directory for {self.ipsw_path} ({arch_label})"
                 )
 
+            span.set_data("extract_dir", directory_data(extract_dir))
             return extract_dir
 
     def run(self) -> Path:
@@ -271,11 +254,8 @@ class IpswExtractor:
             if mount_point:
                 mount_span.set_data("mount_point", str(mount_point))
             elif mount_output_lines:
-                logger.warning(
-                    "Could not determine sys image mount point for %s.\n%s",
-                    self.ipsw_path.name,
-                    format_subprocess_output("mount output", "\n".join(mount_output_lines)),
-                )
+                mount_span.set_data("mount_output_preview", mount_output_lines[:20])
+                logger.warning("Could not determine sys image mount point for %s", self.ipsw_path.name)
 
         try:
             # symsort the entire sys mount-point
@@ -303,63 +283,62 @@ class IpswExtractor:
                     logger.error("Failed to clean up mount point", extra={"mount_point": mount_point, "exception": e})
 
     def _ipsw_split(self, extract_dir: Path, arch: Arch | None = None) -> Path:
-        dsc_root_file = None
-        for item in extract_dir.iterdir():
-            if item.is_file() and not item.suffix:  # check if it is a file and has no extension
-                dsc_root_file = item
-                break
+        arch_label = str(arch) if arch is not None else "default"
+        with sentry_sdk.start_span(op="ipsw.dyld_split", name=f"Split IPSW DSC ({arch_label})") as span:
+            dsc_root_file = None
+            for item in extract_dir.iterdir():
+                if item.is_file() and not item.suffix:  # check if it is a file and has no extension
+                    dsc_root_file = item
+                    break
 
-        if dsc_root_file is None:
-            raise IpswExtractError(
-                f"Failed to find dyld_shared_cache root-file in {extract_dir}\n{describe_directory(extract_dir)}"
-            )
+            span.set_data("extract_dir", directory_data(extract_dir))
+            if dsc_root_file is None:
+                span.set_status("internal_error")
+                raise IpswExtractError(f"Failed to find dyld_shared_cache root-file in {extract_dir}")
 
-        split_dir = self.processing_dir / "split_out"
-        if arch is not None:
-            # each arch gets its own sub-dir, so that the split-dir can be symsorted in one go
-            split_dir_arch = split_dir / str(arch)
-        else:
-            split_dir_arch = split_dir
+            split_dir = self.processing_dir / "split_out"
+            if arch is not None:
+                # each arch gets its own sub-dir, so that the split-dir can be symsorted in one go
+                split_dir_arch = split_dir / str(arch)
+            else:
+                split_dir_arch = split_dir
 
-        result = dyld_split(dsc_root_file, split_dir_arch)
+            span.set_data("dsc_root_file", str(dsc_root_file))
+            result = dyld_split(dsc_root_file, split_dir_arch)
+            span.set_data("dyld_split", subprocess_result_data(result))
+            span.set_data("split_dir", directory_data(split_dir_arch))
 
-        if result.returncode != 0:
-            raise IpswExtractError(
-                "\n".join(
-                    [
-                        f"ipsw dyld split failed for {dsc_root_file}",
-                        format_subprocess_result("dyld split", result),
-                        describe_directory(extract_dir),
-                        describe_directory(split_dir_arch),
-                    ]
-                )
-            )
+            if result.returncode != 0:
+                span.set_status("internal_error")
+                raise IpswExtractError(f"ipsw dyld split failed for {dsc_root_file}")
 
-        # we have very limited space on the GHA runners, so get rid of processed input data
-        shutil.rmtree(extract_dir)
+            # we have very limited space on the GHA runners, so get rid of processed input data
+            shutil.rmtree(extract_dir)
 
-        return split_dir
+            return split_dir
 
     def _symsort(self, split_dir: Path, ignore_errors: bool = False) -> None:
         output_dir = self.symbols_dir()
         logger.info("Symsorting %s -> %s", split_dir, output_dir)
 
-        result = symsort(output_dir, self.prefix, self.bundle_id, split_dir, ignore_errors)
+        with sentry_sdk.start_span(op="ipsw.symsort", name=f"Symsort IPSW {self.bundle_id}") as span:
+            span.set_data("bundle_id", self.bundle_id)
+            span.set_data("split_dir", directory_data(split_dir))
+            span.set_data("output_dir", directory_data(output_dir))
 
-        if result.returncode != 0:
-            raise IpswExtractError(
-                "\n".join(
-                    [
-                        f"Symsorter failed for bundle {self.bundle_id}",
-                        format_subprocess_result("symsorter", result),
-                        describe_directory(split_dir),
-                        describe_directory(output_dir),
-                    ]
-                )
-            )
+            result = symsort(output_dir, self.prefix, self.bundle_id, split_dir, ignore_errors)
+            span.set_data("symsort", subprocess_result_data(result))
+
+            if result.returncode != 0:
+                span.set_status("internal_error")
+                raise IpswExtractError(f"Symsorter failed for bundle {self.bundle_id}")
 
 
 class IpswExtractError(Exception):
+    pass
+
+
+class IpswExtractTimeoutError(IpswExtractError, TimeoutError):
     pass
 
 

--- a/symx/model.py
+++ b/symx/model.py
@@ -77,6 +77,11 @@ class ArtifactProcessingState(StrEnum):
     # boot environment (kernel + small rootfs + firmware) with no DSC
     RECOVERY_OTA = "recovery_ota"
 
+    # the artifact appears to reference a full DSC in post.bom, but the current extractor tooling
+    # (payloadv2 + Apple Archive handling) cannot materialize it. This is terminal for current
+    # automation, but semantically distinct from delta/recovery OTAs which inherently have no full DSC.
+    UNSUPPORTED_OTA_PAYLOAD = "unsupported_ota_payload"
+
     # the symx goal: symbols are stored for symbolicator to grab
     SYMBOLS_EXTRACTED = "symbols_extracted"
 

--- a/symx/ota/extract.py
+++ b/symx/ota/extract.py
@@ -4,9 +4,12 @@ import glob
 import logging
 import os
 import re
+import shutil
 import subprocess
 import tempfile
+import zipfile
 from pathlib import Path
+from typing import TypedDict
 
 import sentry_sdk
 
@@ -28,45 +31,170 @@ from symx.ota.model import (
     MountInfo,
     OtaExtractError,
     RecoveryOtaError,
+    UnsupportedOtaPayloadError,
 )
 
 logger = logging.getLogger(__name__)
 
+PAYLOAD_FILE_NAME_RE = re.compile(r"(^|.*/)payloadv2/payload\.\d+$")
+DYLD_BOM_ENTRY_RE = re.compile(
+    r"^(?:\./)?(?:System/DriverKit/)?System/Library/(?:dyld|Caches/com\.apple\.dyld)/dyld_shared_cache_[^\s/]+$"
+)
+DYLD_AA_INCLUDE_REGEX = r"(System/DriverKit/)?System/Library/(dyld|Caches/com\.apple\.dyld)/dyld_shared_cache_"
+UNSUPPORTED_AA_ERROR_MARKERS = (
+    "invalid/non-supported archive stream",
+    "archive stream read error (header)",
+)
+MAX_AA_PROBE_OUTPUT_CHARS = 500
 
-def _describe_extract_dirs(output_dir: Path) -> str:
+
+class PayloadAaProbeResult(TypedDict):
+    payload: str
+    returncode: int
+    stdout: str | None
+    stderr: str | None
+    extracted_count: int
+    unsupported_error: bool
+
+
+def _extract_dirs_data(output_dir: Path) -> list[dict[str, object]]:
+    if not output_dir.exists() or not output_dir.is_dir():
+        return []
+
     extract_dirs = list_dirs_in(output_dir)
-    if not extract_dirs:
-        return f"No image directories were created in {output_dir}"
-
-    lines = [f"Image directories created in {output_dir}:"]
+    results: list[dict[str, object]] = []
     for extract_dir in extract_dirs:
-        lines.append(f"- {extract_dir}")
-        if _dir_contains_dsc(extract_dir):
-            lines.append(f"  contains at least one {DYLD_SHARED_CACHE}* file")
-            continue
-
-        sample = describe_directory(extract_dir, max_entries=DEFAULT_DIRECTORY_SAMPLE_ENTRIES, indent="    ")
-        lines.extend(f"  {line}" for line in sample.splitlines())
-
-    return "\n".join(lines)
+        data = directory_data(extract_dir, max_entries=DEFAULT_DIRECTORY_SAMPLE_ENTRIES)
+        data["contains_dsc"] = _dir_contains_dsc(extract_dir)
+        results.append(data)
+    return results
 
 
-def _format_extract_ota_error(
-    artifact: Path,
-    output_dir: Path,
-    reason: str,
-    literal_result: subprocess.CompletedProcess[bytes],
-    pattern_result: subprocess.CompletedProcess[bytes] | None,
-) -> str:
-    return "\n".join(
-        [
-            reason,
-            format_subprocess_result("literal extract", literal_result),
-            format_subprocess_result("payloadv2 pattern extract", pattern_result),
-            _describe_extract_dirs(output_dir),
-            f"artifact: {artifact}",
-        ]
+def _should_probe_unsupported_payload(error: OtaExtractError) -> bool:
+    message = str(error)
+    return any(
+        marker in message
+        for marker in (
+            f"Could not find {DYLD_SHARED_CACHE}",
+            f"OTA extraction produced no {DYLD_SHARED_CACHE} files",
+            f"Couldn't find any {DYLD_SHARED_CACHE} paths",
+        )
     )
+
+
+def _ota_is_zip_archive(artifact: Path) -> bool:
+    try:
+        return zipfile.is_zipfile(artifact)
+    except OSError:
+        return False
+
+
+def _payload_entry_names(artifact: Path) -> list[str]:
+    with zipfile.ZipFile(artifact) as archive:
+        return [name for name in archive.namelist() if PAYLOAD_FILE_NAME_RE.search(name)]
+
+
+def _read_post_bom_dsc_matches(artifact: Path) -> list[str]:
+    with zipfile.ZipFile(artifact) as archive:
+        post_bom_name = next((name for name in archive.namelist() if name.endswith("post.bom")), None)
+        if post_bom_name is None:
+            return []
+
+        with tempfile.TemporaryDirectory(suffix="_ota_post_bom") as post_bom_tmp_dir:
+            bom_path = Path(post_bom_tmp_dir) / Path(post_bom_name).name
+            bom_path.write_bytes(archive.read(post_bom_name))
+            result = subprocess.run(["lsbom", str(bom_path)], capture_output=True, text=True)
+
+        if result.returncode != 0:
+            return []
+
+        matches: list[str] = []
+        for line in result.stdout.splitlines():
+            entry = line.split("\t", 1)[0].strip()
+            if DYLD_BOM_ENTRY_RE.match(entry):
+                matches.append(entry.removeprefix("./"))
+        return matches
+
+
+def _aa_result_indicates_unsupported_payload(stdout: str | bytes | None, stderr: str | bytes | None) -> bool:
+    combined = "\n".join(
+        part for part in (decode_subprocess_output(stdout), decode_subprocess_output(stderr)) if part
+    ).lower()
+    return any(marker in combined for marker in UNSUPPORTED_AA_ERROR_MARKERS)
+
+
+def _probe_payload_with_aa(artifact: Path, payload_name: str, pattern: str) -> PayloadAaProbeResult:
+    with tempfile.TemporaryDirectory(suffix="_ota_aa_probe") as aa_probe_dir:
+        output_dir = Path(aa_probe_dir) / "out"
+        output_dir.mkdir(parents=True, exist_ok=True)
+        payload_input_path = Path(aa_probe_dir) / "payload_input.bin"
+
+        with zipfile.ZipFile(artifact) as archive:
+            with archive.open(payload_name) as payload_stream, payload_input_path.open("wb") as payload_input_file:
+                shutil.copyfileobj(payload_stream, payload_input_file)
+
+        with payload_input_path.open("rb") as payload_input_file:
+            result = subprocess.run(
+                ["aa", "extract", "-d", str(output_dir), "-include-regex", pattern],
+                stdin=payload_input_file,
+                capture_output=True,
+            )
+
+        extracted_count = sum(1 for path in output_dir.rglob("*") if path.is_file())
+        return {
+            "payload": payload_name,
+            "returncode": result.returncode,
+            "stdout": truncate_text(result.stdout, max_chars=MAX_AA_PROBE_OUTPUT_CHARS),
+            "stderr": truncate_text(result.stderr, max_chars=MAX_AA_PROBE_OUTPUT_CHARS),
+            "extracted_count": extracted_count,
+            "unsupported_error": _aa_result_indicates_unsupported_payload(result.stdout, result.stderr),
+        }
+
+
+def _probe_unsupported_payload_format(artifact: Path) -> bool:
+    with sentry_sdk.start_span(op="ota.extract.payload_probe", name="Probe unsupported OTA payload") as span:
+        span.set_data("artifact", str(artifact))
+
+        try:
+            if not _ota_is_zip_archive(artifact):
+                span.set_data("is_zip_archive", False)
+                return False
+
+            span.set_data("is_zip_archive", True)
+            bom_matches = _read_post_bom_dsc_matches(artifact)
+            span.set_data("post_bom_dsc_match_count", len(bom_matches))
+            span.set_data("post_bom_dsc_matches", bom_matches[:10])
+            if not bom_matches:
+                return False
+
+            payload_names = _payload_entry_names(artifact)
+            span.set_data("payload_probe_count", len(payload_names))
+            if not payload_names:
+                return False
+
+            results = [
+                _probe_payload_with_aa(artifact, payload_name, DYLD_AA_INCLUDE_REGEX) for payload_name in payload_names
+            ]
+            extracted_total = sum(result["extracted_count"] for result in results)
+            unsupported_errors = sum(1 for result in results if result["unsupported_error"])
+            other_errors = sum(1 for result in results if result["returncode"] != 0 and not result["unsupported_error"])
+            span.set_data(
+                "payload_probe_summary",
+                {
+                    "payloads_probed": len(results),
+                    "extracted_total": extracted_total,
+                    "unsupported_errors": unsupported_errors,
+                    "other_errors": other_errors,
+                },
+            )
+            span.set_data("payload_probe_results", results[:10])
+
+            unsupported = extracted_total == 0 and unsupported_errors > 0 and other_errors == 0
+            span.set_data("unsupported_payload_format", unsupported)
+            return unsupported
+        except (FileNotFoundError, OSError, ValueError, zipfile.BadZipFile) as exc:
+            span.set_data("payload_probe_error", str(exc))
+            return False
 
 
 def parse_cryptex_patch_output(stderr: str) -> dict[str, Path]:
@@ -301,15 +429,6 @@ def extract_ota(artifact: Path, output_dir: Path) -> Path | None:
             raise OtaExtractError(f"Found more than one image directory in {artifact}")
         elif not _dir_contains_dsc(extract_dirs[0]):
             span.set_status("internal_error")
-            raise OtaExtractError(
-                _format_extract_ota_error(
-                    artifact,
-                    output_dir,
-                    f"OTA extraction produced no {DYLD_SHARED_CACHE} files for {artifact}",
-                    literal_result,
-                    pattern_result,
-                )
-            )
             span.set_data(
                 "extract_failure_reason", f"OTA extraction produced no {DYLD_SHARED_CACHE} files for {artifact}"
             )
@@ -368,6 +487,8 @@ def _process_ota_directly(
         error_cls = _classify_ota_failure(local_ota)
         if error_cls is not None:
             raise error_cls(f"{error_cls.__name__}: {local_ota}") from e
+        if _should_probe_unsupported_payload(e) and _probe_unsupported_payload_format(local_ota):
+            raise UnsupportedOtaPayloadError(f"Unsupported OTA payload format: {local_ota}") from e
         raise
 
     return []

--- a/symx/ota/extract.py
+++ b/symx/ota/extract.py
@@ -10,7 +10,13 @@ from pathlib import Path
 
 import sentry_sdk
 
-from symx.diagnostics import DEFAULT_DIRECTORY_SAMPLE_ENTRIES, describe_directory, format_subprocess_result
+from symx.diagnostics import (
+    DEFAULT_DIRECTORY_SAMPLE_ENTRIES,
+    decode_subprocess_output,
+    directory_data,
+    subprocess_result_data,
+    truncate_text,
+)
 from symx.model import Arch
 from symx.fs import list_dirs_in, rmdir_if_exists
 from symx.tools import dyld_split, symsort as common_symsort
@@ -257,8 +263,6 @@ def extract_ota(artifact: Path, output_dir: Path) -> Path | None:
             ],
             capture_output=True,
         )
-        span.set_data("literal_extract.returncode", literal_result.returncode)
-
         pattern_result: subprocess.CompletedProcess[bytes] | None = None
         extract_dirs = list_dirs_in(output_dir)
         if not extract_dirs or not _dir_contains_dsc(extract_dirs[0]):
@@ -281,31 +285,20 @@ def extract_ota(artifact: Path, output_dir: Path) -> Path | None:
                 ],
                 capture_output=True,
             )
-            span.set_data("pattern_extract.returncode", pattern_result.returncode)
             extract_dirs = list_dirs_in(output_dir)
+
+        span.set_data("literal_extract", subprocess_result_data(literal_result))
+        span.set_data("payloadv2_pattern_extract", subprocess_result_data(pattern_result))
+        span.set_data("extract_dirs", _extract_dirs_data(output_dir))
 
         if not extract_dirs:
             span.set_status("internal_error")
-            raise OtaExtractError(
-                _format_extract_ota_error(
-                    artifact,
-                    output_dir,
-                    f"Could not find {DYLD_SHARED_CACHE} in {artifact}",
-                    literal_result,
-                    pattern_result,
-                )
-            )
+            span.set_data("extract_failure_reason", f"Could not find {DYLD_SHARED_CACHE} in {artifact}")
+            raise OtaExtractError(f"Could not find {DYLD_SHARED_CACHE} in {artifact}")
         elif len(extract_dirs) > 1:
             span.set_status("internal_error")
-            raise OtaExtractError(
-                _format_extract_ota_error(
-                    artifact,
-                    output_dir,
-                    f"Found more than one image directory in {artifact}",
-                    literal_result,
-                    pattern_result,
-                )
-            )
+            span.set_data("extract_failure_reason", f"Found more than one image directory in {artifact}")
+            raise OtaExtractError(f"Found more than one image directory in {artifact}")
         elif not _dir_contains_dsc(extract_dirs[0]):
             span.set_status("internal_error")
             raise OtaExtractError(
@@ -317,6 +310,10 @@ def extract_ota(artifact: Path, output_dir: Path) -> Path | None:
                     pattern_result,
                 )
             )
+            span.set_data(
+                "extract_failure_reason", f"OTA extraction produced no {DYLD_SHARED_CACHE} files for {artifact}"
+            )
+            raise OtaExtractError(f"OTA extraction produced no {DYLD_SHARED_CACHE} files for {artifact}")
 
         logger.info("Successfully extracted DSC from %s", artifact.name)
 

--- a/symx/ota/model.py
+++ b/symx/ota/model.py
@@ -149,6 +149,12 @@ class RecoveryOtaError(Exception):
     pass
 
 
+class UnsupportedOtaPayloadError(Exception):
+    """Raised when an OTA references a DSC but current tooling cannot extract its payload format."""
+
+    pass
+
+
 # -- Utilities --
 
 

--- a/symx/ota/runners.py
+++ b/symx/ota/runners.py
@@ -23,6 +23,7 @@ from symx.ota.model import (
     OtaStorage,
     OtaSymbolExtractor,
     RecoveryOtaError,
+    UnsupportedOtaPayloadError,
     parse_version_tuple,
 )
 from symx.ota.extract import extract_symbols
@@ -228,6 +229,20 @@ class OtaExtract:
                         artifacts_skipped += 1
                         sentry_sdk.metrics.count(
                             "ota.extract.skipped_recovery", 1, attributes={"platform": ota.platform}
+                        )
+                    except UnsupportedOtaPayloadError:
+                        logger.info(
+                            "Skipping unsupported OTA payload %s %s %s (current tooling cannot extract payloadv2 DSC)",
+                            ota.platform,
+                            ota.version,
+                            ota.build,
+                        )
+                        ota.processing_state = ArtifactProcessingState.UNSUPPORTED_OTA_PAYLOAD
+                        ota.update_last_run()
+                        self.storage.update_meta_item(key, ota)
+                        artifacts_skipped += 1
+                        sentry_sdk.metrics.count(
+                            "ota.extract.skipped_unsupported_payload", 1, attributes={"platform": ota.platform}
                         )
                     except OtaExtractError as e:
                         sentry_sdk.capture_exception(e)

--- a/tests/test_extract_utils.py
+++ b/tests/test_extract_utils.py
@@ -5,8 +5,11 @@ These are pure functions or functions with minimal I/O that support
 the OTA and IPSW extraction workflows.
 """
 
+import subprocess
 import tempfile
+import zipfile
 from pathlib import Path
+from typing import BinaryIO, cast
 
 import pytest
 
@@ -14,15 +17,19 @@ from symx.model import Arch
 from symx.ipsw.model import IpswPlatform
 from symx.ipsw.extract import (
     IpswExtractError,
+    IpswExtractTimeoutError,
     IpswExtractor,
-    map_platform_to_prefix,
     find_extraction_dir,
     generate_bundle_id,
+    map_platform_to_prefix,
 )
 from subprocess import CompletedProcess
 
 from symx.ota.model import DSCSearchResult, OtaExtractError
 from symx.ota.extract import (
+    DYLD_AA_INCLUDE_REGEX,
+    _probe_payload_with_aa,
+    _probe_unsupported_payload_format,
     extract_ota,
     find_dsc,
     parse_cryptex_patch_output,
@@ -440,3 +447,86 @@ def test_extract_ota_falls_back_to_pattern_extract(monkeypatch: pytest.MonkeyPat
         monkeypatch.setattr("symx.ota.extract.subprocess.run", fake_run)
 
         assert extract_ota(Path("/tmp/test.ota"), output_dir) == image_dir
+
+
+def test_probe_payload_with_aa_materializes_zip_member_for_subprocess_stdin(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    artifact = tmp_path / "test.zip"
+    payload_name = "AssetData/payloadv2/payload.000"
+    payload_bytes = b"payloadv2 bytes"
+
+    with zipfile.ZipFile(artifact, "w") as archive:
+        archive.writestr(payload_name, payload_bytes)
+
+    def fake_run(args: list[str], stdin: object | None = None, capture_output: bool = False) -> CompletedProcess[bytes]:
+        assert stdin is not None
+        stdin_file = cast(BinaryIO, stdin)
+        stdin_file.fileno()
+        assert stdin_file.read() == payload_bytes
+        return CompletedProcess(args=args, returncode=1, stdout=b"", stderr=b"Invalid/non-supported archive stream")
+
+    monkeypatch.setattr("symx.ota.extract.subprocess.run", fake_run)
+
+    result = _probe_payload_with_aa(artifact, payload_name, DYLD_AA_INCLUDE_REGEX)
+
+    assert result["payload"] == payload_name
+    assert result["returncode"] == 1
+    assert result["extracted_count"] == 0
+    assert result["unsupported_error"] is True
+
+
+def test_probe_unsupported_payload_format_returns_true_for_consistent_aa_legacy_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = Path("/tmp/test.zip")
+
+    monkeypatch.setattr("symx.ota.extract._ota_is_zip_archive", lambda artifact: True)
+    monkeypatch.setattr(
+        "symx.ota.extract._read_post_bom_dsc_matches",
+        lambda artifact: ["System/Library/Caches/com.apple.dyld/dyld_shared_cache_armv7k"],
+    )
+    monkeypatch.setattr(
+        "symx.ota.extract._payload_entry_names",
+        lambda artifact: ["AssetData/payloadv2/payload.000", "AssetData/payloadv2/payload.001"],
+    )
+
+    def fake_probe_payload_with_aa(artifact: Path, payload_name: str, pattern: str) -> dict[str, object]:
+        return {
+            "payload": payload_name,
+            "returncode": 1,
+            "stdout": None,
+            "stderr": "Invalid/non-supported archive stream",
+            "extracted_count": 0,
+            "unsupported_error": True,
+        }
+
+    monkeypatch.setattr("symx.ota.extract._probe_payload_with_aa", fake_probe_payload_with_aa)
+
+    assert _probe_unsupported_payload_format(artifact) is True
+
+
+def test_probe_unsupported_payload_format_returns_false_when_payload_extracts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = Path("/tmp/test.zip")
+
+    monkeypatch.setattr("symx.ota.extract._ota_is_zip_archive", lambda artifact: True)
+    monkeypatch.setattr(
+        "symx.ota.extract._read_post_bom_dsc_matches",
+        lambda artifact: ["System/Library/Caches/com.apple.dyld/dyld_shared_cache_arm64e"],
+    )
+    monkeypatch.setattr("symx.ota.extract._payload_entry_names", lambda artifact: ["AssetData/payloadv2/payload.003"])
+    monkeypatch.setattr(
+        "symx.ota.extract._probe_payload_with_aa",
+        lambda artifact, payload_name, pattern: {
+            "payload": payload_name,
+            "returncode": 0,
+            "stdout": None,
+            "stderr": None,
+            "extracted_count": 1,
+            "unsupported_error": False,
+        },
+    )
+
+    assert _probe_unsupported_payload_format(artifact) is False

--- a/tests/test_extract_utils.py
+++ b/tests/test_extract_utils.py
@@ -108,6 +108,41 @@ def _make_ipsw_extractor(tmp_path: Path) -> IpswExtractor:
     return IpswExtractor(IpswPlatform.IPADOS, "iPad15,7_26.4.2_23E261_Restore.ipsw", processing_dir, ipsw_path)
 
 
+def test_ipsw_extract_dsc_timeout_preserves_timeout_contract_and_diagnostics(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    extractor = _make_ipsw_extractor(tmp_path)
+
+    class FakePopen:
+        def __init__(self, command: list[str], stdout: object = None, stderr: object = None) -> None:
+            self.command = command
+            self.returncode = 0
+
+        def __enter__(self) -> "FakePopen":
+            return self
+
+        def __exit__(self, exc_type: object, exc: object, tb: object) -> bool:
+            return False
+
+        def communicate(self, timeout: int | None = None) -> tuple[bytes, bytes]:
+            if timeout is not None:
+                raise subprocess.TimeoutExpired(self.command, timeout)
+            return b"timeout stdout", b"timeout stderr"
+
+        def kill(self) -> None:
+            self.returncode = -9
+
+    monkeypatch.setattr("symx.ipsw.extract.subprocess.Popen", FakePopen)
+
+    with pytest.raises(TimeoutError, match="ipsw extract timed out") as exc_info:
+        extractor._ipsw_extract_dsc()
+
+    assert isinstance(exc_info.value, IpswExtractTimeoutError)
+    assert isinstance(exc_info.value, IpswExtractError)
+    message = str(exc_info.value)
+    assert message == f"ipsw extract timed out for {extractor.ipsw_path} (default)"
+
+
 def test_ipsw_extract_dsc_raises_detailed_error_when_extract_fails(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -136,10 +171,7 @@ def test_ipsw_extract_dsc_raises_detailed_error_when_extract_fails(
         extractor._ipsw_extract_dsc()
 
     message = str(exc_info.value)
-    assert "extract stdout" in message
-    assert "extract stderr" in message
-    assert "command: ipsw extract" in message
-    assert str(extractor.processing_dir) in message
+    assert message == f"ipsw extract failed for {extractor.ipsw_path} (default) with exit code 1"
 
 
 def test_ipsw_split_raises_detailed_error_when_split_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -159,10 +191,7 @@ def test_ipsw_split_raises_detailed_error_when_split_fails(tmp_path: Path, monke
         extractor._ipsw_split(extract_dir)
 
     message = str(exc_info.value)
-    assert "split stdout" in message
-    assert "split stderr" in message
-    assert str(extract_dir) in message
-    assert "split_out" in message
+    assert message == f"ipsw dyld split failed for {extract_dir / 'dyld_shared_cache_arm64e'}"
 
 
 def test_ipsw_symsort_raises_detailed_error_when_symsorter_fails(
@@ -184,10 +213,7 @@ def test_ipsw_symsort_raises_detailed_error_when_symsorter_fails(
         extractor._symsort(split_dir)
 
     message = str(exc_info.value)
-    assert "symsort stdout" in message
-    assert "symsort stderr" in message
-    assert str(split_dir) in message
-    assert str(extractor.symbols_dir()) in message
+    assert message == f"Symsorter failed for bundle {extractor.bundle_id}"
 
 
 # --- parse_cryptex_patch_output tests ---
@@ -394,11 +420,7 @@ def test_extract_ota_raises_detailed_error_when_no_dsc_extracted(monkeypatch: py
             extract_ota(Path("/tmp/test.ota"), output_dir)
 
         message = str(exc_info.value)
-        assert "literal extract: exit=1" in message
-        assert "payloadv2 pattern extract: exit=0" in message
-        assert "literal stdout" in message
-        assert "pattern stderr" in message
-        assert str(image_dir) in message
+        assert message == "OTA extraction produced no dyld_shared_cache files for /tmp/test.ota"
 
 
 def test_extract_ota_falls_back_to_pattern_extract(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_ota_extract.py
+++ b/tests/test_ota_extract.py
@@ -15,6 +15,7 @@ from symx.ota.model import (
     OtaExtractError,
     OtaMetaData,
     RecoveryOtaError,
+    UnsupportedOtaPayloadError,
 )
 from symx.ota.runners import OtaExtract
 from tests.fakes import FakeTimeout
@@ -183,6 +184,20 @@ def test_recovery_ota_skipped(tmp_path: Path) -> None:
     OtaExtract(storage, extractor=extractor).extract(FakeTimeout(timedelta(minutes=5)))
 
     assert storage.artifacts["key1"].processing_state == ArtifactProcessingState.RECOVERY_OTA
+
+
+def test_unsupported_payload_ota_skipped(tmp_path: Path) -> None:
+    """OTAs unsupported by current payload tooling are terminal-stated and skipped."""
+    storage = MockStorage({"key1": make_ota_artifact(id="key1")})
+    ota_file = tmp_path / "test.zip"
+    ota_file.touch()
+    storage.load_ota_returns = ota_file
+
+    extractor = FakeOtaExtractor(error=UnsupportedOtaPayloadError("unsupported payload"))
+
+    OtaExtract(storage, extractor=extractor).extract(FakeTimeout(timedelta(minutes=5)))
+
+    assert storage.artifacts["key1"].processing_state == ArtifactProcessingState.UNSUPPORTED_OTA_PAYLOAD
 
 
 def test_timeout_stops_processing(tmp_path: Path) -> None:


### PR DESCRIPTION
In particular, use more Sentry for metadata and less string formatting.

Also:
* preserve previous IPSW timeout semantics
* also fix the TUI status callback
* add classification for unsupported OTA `payloadv2` (so they aren't falsly flagged as extraction errors)