### PR TITLE
fix(admin): optimize queue batching validation

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -2,8 +2,5 @@
   "strict": [
     "symx/**"
   ],
-  "stubPath": "typings",
-  "ignore": [
-    "symx/ipsw/meta_sync/meta_df.py"
-  ]
+  "stubPath": "typings"
 }

--- a/symx/admin/actions.py
+++ b/symx/admin/actions.py
@@ -225,13 +225,17 @@ def snapshot_generation_for_store(snapshot_info: SnapshotInfo, store: AdminStore
 
 
 def _create_target_preview(
-    action: AdminActionKind, processing_state: ArtifactProcessingState, mirror_path: str | None, label: str
+    store: AdminStore,
+    action: AdminActionKind,
+    processing_state: ArtifactProcessingState,
+    required_path: str | None,
+    label: str,
 ) -> SnapshotTargetPreview:
     preview = preview_action(
-        AdminStore.OTA,
+        store,
         action,
         processing_state,
-        has_required_path=mirror_path is not None,
+        has_required_path=required_path is not None,
     )
     return SnapshotTargetPreview(
         allowed=preview.allowed,
@@ -257,7 +261,13 @@ def preview_target_against_snapshot(
         if row is None:
             return SnapshotTargetPreview(False, None, None, "missing from current snapshot")
         else:
-            return _create_target_preview(action, row.processing_state, row.mirror_path, row.file_name)
+            return _create_target_preview(
+                store,
+                action,
+                row.processing_state,
+                row.mirror_path,
+                row.file_name,
+            )
 
     if not isinstance(target, OtaTarget):
         return SnapshotTargetPreview(False, None, None, "unexpected target type for ota batch")
@@ -266,7 +276,13 @@ def preview_target_against_snapshot(
     if row is None:
         return SnapshotTargetPreview(False, None, None, "missing from current snapshot")
     else:
-        return _create_target_preview(action, row.processing_state, row.download_path, row.artifact_id)
+        return _create_target_preview(
+            store,
+            action,
+            row.processing_state,
+            row.download_path,
+            row.artifact_id,
+        )
 
 
 def validate_pending_batch_against_snapshot(

--- a/symx/admin/actions.py
+++ b/symx/admin/actions.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from dataclasses import asdict, dataclass, replace
 from enum import StrEnum
 from typing import cast
 
-from symx.admin.db import SnapshotInfo
+from symx.admin.db import IpswSourceRow, OtaArtifactRow, SnapshotInfo
 from symx.model import ArtifactProcessingState
 
 
@@ -68,18 +69,14 @@ class ApplyBatchRequest:
         return json.dumps(asdict(self), separators=(",", ":"), sort_keys=True)
 
     @classmethod
-    def from_json(cls, payload: str) -> ApplyBatchRequest:
-        raw_payload: object = json.loads(payload)
-        if not isinstance(raw_payload, dict):
-            raise ValueError("Unexpected apply batch payload")
-
-        payload_dict = cast(dict[str, object], raw_payload)
-        store = AdminStore(str(payload_dict["store"]))
-        action = AdminActionKind(str(payload_dict["action"]))
-        snapshot_id = str(payload_dict["snapshot_id"])
-        base_generation = _coerce_int(payload_dict["base_generation"])
-        reason = str(payload_dict["reason"])
-        raw_targets = payload_dict.get("targets")
+    def from_json(cls, payload_raw: str) -> ApplyBatchRequest:
+        payload: dict[str, object] = json.loads(payload_raw)
+        store = AdminStore(str(payload["store"]))
+        action = AdminActionKind(str(payload["action"]))
+        snapshot_id = str(payload["snapshot_id"])
+        base_generation = _coerce_int(payload["base_generation"])
+        reason = str(payload["reason"])
+        raw_targets = payload.get("targets")
         if not isinstance(raw_targets, list):
             raise ValueError("Unexpected targets payload")
 
@@ -118,14 +115,10 @@ class ApplyBatchResult:
         return json.dumps(asdict(self), separators=(",", ":"), sort_keys=True)
 
     @classmethod
-    def from_json(cls, payload: str) -> ApplyBatchResult:
-        raw_payload: object = json.loads(payload)
-        if not isinstance(raw_payload, dict):
-            raise ValueError("Unexpected apply result payload")
-
-        payload_dict = cast(dict[str, object], raw_payload)
-        store = AdminStore(str(payload_dict["store"]))
-        worker_payload = payload_dict.get("worker")
+    def from_json(cls, payload_raw: str) -> ApplyBatchResult:
+        payload: dict[str, object] = json.loads(payload_raw)
+        store = AdminStore(str(payload["store"]))
+        worker_payload = payload.get("worker")
         worker: WorkerDispatchResult | None = None
         if isinstance(worker_payload, dict):
             worker_dict = cast(dict[str, object], worker_payload)
@@ -135,21 +128,21 @@ class ApplyBatchResult:
                 detail=_optional_str(worker_dict.get("detail")),
             )
 
-        raw_targets = payload_dict.get("targets")
+        raw_targets = payload.get("targets")
         if not isinstance(raw_targets, list):
             raise ValueError("Unexpected targets payload")
 
         return cls(
-            status=ApplyBatchStatus(str(payload_dict["status"])),
+            status=ApplyBatchStatus(str(payload["status"])),
             store=store,
-            action=AdminActionKind(str(payload_dict["action"])),
-            snapshot_id=str(payload_dict["snapshot_id"]),
-            base_generation=_coerce_int(payload_dict["base_generation"]),
-            remote_generation=_coerce_int(payload_dict["remote_generation"]),
+            action=AdminActionKind(str(payload["action"])),
+            snapshot_id=str(payload["snapshot_id"]),
+            base_generation=_coerce_int(payload["base_generation"]),
+            remote_generation=_coerce_int(payload["remote_generation"]),
             targets=_parse_targets(store, cast(list[object], raw_targets)),
-            reason=str(payload_dict["reason"]),
-            applied_count=_coerce_int(payload_dict["applied_count"]),
-            message=str(payload_dict["message"]),
+            reason=str(payload["reason"]),
+            applied_count=_coerce_int(payload["applied_count"]),
+            message=str(payload["message"]),
             worker=worker,
         )
 
@@ -159,6 +152,21 @@ class ActionPreview:
     allowed: bool
     resulting_state: ArtifactProcessingState | None
     note: str
+
+
+@dataclass(frozen=True)
+class SnapshotTargetPreview:
+    allowed: bool
+    current_state: ArtifactProcessingState | None
+    resulting_state: ArtifactProcessingState | None
+    note: str
+    row_label: str | None = None
+
+
+@dataclass(frozen=True)
+class ValidationIssue:
+    target: str
+    reason: str
 
 
 def add_target_to_pending_batch(batch: PendingBatch | None, target: AdminTarget) -> PendingBatch:
@@ -216,6 +224,74 @@ def snapshot_generation_for_store(snapshot_info: SnapshotInfo, store: AdminStore
     return snapshot_info.ota_generation
 
 
+def _create_target_preview(
+    action: AdminActionKind, processing_state: ArtifactProcessingState, mirror_path: str | None, label: str
+) -> SnapshotTargetPreview:
+    preview = preview_action(
+        AdminStore.OTA,
+        action,
+        processing_state,
+        has_required_path=mirror_path is not None,
+    )
+    return SnapshotTargetPreview(
+        allowed=preview.allowed,
+        current_state=processing_state,
+        resulting_state=preview.resulting_state,
+        note=preview.note,
+        row_label=label,
+    )
+
+
+def preview_target_against_snapshot(
+    store: AdminStore,
+    action: AdminActionKind,
+    target: AdminTarget,
+    ipsw_rows_by_key: Mapping[str, IpswSourceRow],
+    ota_rows_by_key: Mapping[str, OtaArtifactRow],
+) -> SnapshotTargetPreview:
+    if store == AdminStore.IPSW:
+        if not isinstance(target, IpswTarget):
+            return SnapshotTargetPreview(False, None, None, "unexpected target type for ipsw batch")
+
+        row = ipsw_rows_by_key.get(_ipsw_target_row_key(target))
+        if row is None:
+            return SnapshotTargetPreview(False, None, None, "missing from current snapshot")
+        else:
+            return _create_target_preview(action, row.processing_state, row.mirror_path, row.file_name)
+
+    if not isinstance(target, OtaTarget):
+        return SnapshotTargetPreview(False, None, None, "unexpected target type for ota batch")
+
+    row = ota_rows_by_key.get(target.ota_key)
+    if row is None:
+        return SnapshotTargetPreview(False, None, None, "missing from current snapshot")
+    else:
+        return _create_target_preview(action, row.processing_state, row.download_path, row.artifact_id)
+
+
+def validate_pending_batch_against_snapshot(
+    batch: PendingBatch,
+    ipsw_rows_by_key: Mapping[str, IpswSourceRow],
+    ota_rows_by_key: Mapping[str, OtaArtifactRow],
+) -> tuple[ValidationIssue, ...]:
+    issues: list[ValidationIssue] = []
+    for target in batch.targets:
+        preview = preview_target_against_snapshot(
+            batch.store,
+            batch.action,
+            target,
+            ipsw_rows_by_key,
+            ota_rows_by_key,
+        )
+        if not preview.allowed or preview.resulting_state is None:
+            issues.append(ValidationIssue(target=target_label(target), reason=preview.note))
+    return tuple(issues)
+
+
+def format_validation_issues(issues: tuple[ValidationIssue, ...]) -> str:
+    return "; ".join(f"{issue.target}: {issue.reason}" for issue in issues)
+
+
 def worker_workflow_for_action(store: AdminStore, action: AdminActionKind) -> str:
     if store == AdminStore.IPSW and action == AdminActionKind.QUEUE_EXTRACT:
         return "symx-ipsw-extract.yml"
@@ -268,6 +344,10 @@ def _excluded_states(store: AdminStore) -> frozenset[ArtifactProcessingState]:
             ArtifactProcessingState.UNSUPPORTED_OTA_PAYLOAD,
         }
     )
+
+
+def _ipsw_target_row_key(target: IpswTarget) -> str:
+    return f"{target.artifact_key}::{target.link}"
 
 
 def _parse_targets(store: AdminStore, raw_targets: list[object]) -> tuple[AdminTarget, ...]:

--- a/symx/admin/apply.py
+++ b/symx/admin/apply.py
@@ -1,17 +1,18 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-
-from symx.admin.actions import AdminStore, ApplyBatchRequest, IpswTarget, OtaTarget, preview_action, target_label
+from symx.admin.actions import (
+    AdminStore,
+    ApplyBatchRequest,
+    IpswTarget,
+    OtaTarget,
+    ValidationIssue,
+    format_validation_issues,
+    preview_action,
+    target_label,
+)
 from symx.ipsw.model import IpswArtifactDb, IpswSource
 from symx.model import ArtifactProcessingState
 from symx.ota.model import OtaArtifact
-
-
-@dataclass(frozen=True)
-class ValidationIssue:
-    target: str
-    reason: str
 
 
 class AdminApplyValidationError(RuntimeError):
@@ -97,10 +98,6 @@ def apply_request_to_ota_meta(ota_meta: dict[str, OtaArtifact], request: ApplyBa
         artifact.update_last_run()
 
     return len(resolved_targets)
-
-
-def format_validation_issues(issues: tuple[ValidationIssue, ...]) -> str:
-    return "; ".join(f"{issue.target}: {issue.reason}" for issue in issues)
 
 
 def _find_ipsw_source(sources: list[IpswSource], link: str) -> IpswSource | None:

--- a/symx/admin/tui.py
+++ b/symx/admin/tui.py
@@ -27,8 +27,10 @@ from symx.admin.actions import (
     add_target_to_pending_batch,
     batch_summary,
     bind_pending_batch,
-    preview_action,
+    format_validation_issues,
+    preview_target_against_snapshot,
     target_label,
+    validate_pending_batch_against_snapshot,
     with_pending_batch_reason,
 )
 from symx.admin.db import (
@@ -369,6 +371,10 @@ class AdminTui(App[None]):
         if self._current_snapshot_info is None:
             self._set_status("No snapshot is loaded yet.")
             return
+        validation_error = self._pending_batch_validation_error(self._pending_batch)
+        if validation_error is not None:
+            self._set_status(f"Cannot apply pending batch: {validation_error}")
+            return
         if self._pending_batch.reason.strip():
             self._start_apply_thread(self._pending_batch)
             return
@@ -563,32 +569,18 @@ class AdminTui(App[None]):
         if batch is None:
             return target_label(target)
 
-        if isinstance(target, IpswTarget):
-            row = self._all_ipsw_rows_by_key.get(f"{target.artifact_key}::{target.link}")
-            if row is None:
-                return f"{target_label(target)} (missing from current snapshot)"
-            preview = preview_action(
-                AdminStore.IPSW,
-                batch.action,
-                row.processing_state,
-                has_required_path=row.mirror_path is not None,
-            )
-            if preview.resulting_state is None:
-                return f"{target_label(target)} ({preview.note})"
-            return f"{row.file_name}: {row.processing_state.value} -> {preview.resulting_state.value} ({preview.note})"
-
-        row = self._all_ota_rows_by_key.get(target.ota_key)
-        if row is None:
-            return f"{target_label(target)} (missing from current snapshot)"
-        preview = preview_action(
-            AdminStore.OTA,
+        preview = preview_target_against_snapshot(
+            batch.store,
             batch.action,
-            row.processing_state,
-            has_required_path=row.download_path is not None,
+            target,
+            self._all_ipsw_rows_by_key,
+            self._all_ota_rows_by_key,
         )
-        if preview.resulting_state is None:
+        if preview.current_state is None or preview.row_label is None:
             return f"{target_label(target)} ({preview.note})"
-        return f"{row.artifact_id}: {row.processing_state.value} -> {preview.resulting_state.value} ({preview.note})"
+        if preview.resulting_state is None:
+            return f"{preview.row_label}: {preview.current_state.value} ({preview.note})"
+        return f"{preview.row_label}: {preview.current_state.value} -> {preview.resulting_state.value} ({preview.note})"
 
     def _detail_text(self) -> str:
         if self._active_table_id == "tasks" and self._selected_task_id is not None:
@@ -656,12 +648,28 @@ class AdminTui(App[None]):
             return
 
         store, target = selected
+        if self._pending_batch is not None and (
+            self._pending_batch.store != store or self._pending_batch.action != action
+        ):
+            self._set_status("Pending batch already targets a different store or action. Clear it first.")
+            return
+
+        preview = preview_target_against_snapshot(
+            store,
+            action,
+            target,
+            self._all_ipsw_rows_by_key,
+            self._all_ota_rows_by_key,
+        )
+        if not preview.allowed or preview.resulting_state is None:
+            self._set_status(
+                f"Cannot add {target_label(target)} to {action_label(action).lower()} batch: {preview.note}."
+            )
+            return
+
         if self._pending_batch is None:
             self._pending_batch = PendingBatch(store=store, action=action, targets=(target,))
         else:
-            if self._pending_batch.store != store or self._pending_batch.action != action:
-                self._set_status("Pending batch already targets a different store or action. Clear it first.")
-                return
             previous_count = len(self._pending_batch.targets)
             self._pending_batch = add_target_to_pending_batch(self._pending_batch, target)
             if len(self._pending_batch.targets) == previous_count:
@@ -754,6 +762,11 @@ class AdminTui(App[None]):
         self._set_status(f"New snapshot {result.snapshot_id} is ready. Press 'u' to switch.")
 
     def _start_apply_thread(self, batch: PendingBatch) -> None:
+        validation_error = self._pending_batch_validation_error(batch)
+        if validation_error is not None:
+            self._set_status(f"Cannot apply pending batch: {validation_error}")
+            return
+
         if self._apply_thread is not None and self._apply_thread.is_alive():
             self._set_status("Apply already running…")
             return
@@ -999,6 +1012,16 @@ class AdminTui(App[None]):
         self._selected_task_id = self._restore_task_selection(table, previous_task_id, task_ids)
         self._ensure_active_table()
 
+    def _pending_batch_validation_error(self, batch: PendingBatch) -> str | None:
+        issues = validate_pending_batch_against_snapshot(
+            batch,
+            self._all_ipsw_rows_by_key,
+            self._all_ota_rows_by_key,
+        )
+        if not issues:
+            return None
+        return format_validation_issues(issues)
+
     def _status_from_thread(self, message: str) -> None:
         self.call_from_thread(self._set_status, message)
 
@@ -1023,6 +1046,10 @@ class AdminTui(App[None]):
             return
         self._pending_batch = with_pending_batch_reason(self._pending_batch, result)
         self._refresh_pending_batch()
+        validation_error = self._pending_batch_validation_error(self._pending_batch)
+        if validation_error is not None:
+            self._set_status(f"Cannot apply pending batch: {validation_error}")
+            return
         self._start_apply_thread(self._pending_batch)
 
     def _subtitle(self) -> str:

--- a/tests/test_admin_actions.py
+++ b/tests/test_admin_actions.py
@@ -166,6 +166,36 @@ def test_preview_target_against_snapshot_uses_snapshot_rows_and_blocks_missing_e
     assert ota_preview.note == "download_path is required to queue extract"
 
 
+def test_preview_target_against_snapshot_uses_ipsw_mirror_path_label_for_extract_errors() -> None:
+    ipsw_row = IpswSourceRow(
+        last_modified="2024-09-03T12:34:56",
+        processing_state=ArtifactProcessingState.SYMBOL_EXTRACTION_FAILED,
+        platform="iOS",
+        version="18.0",
+        build="22A100",
+        artifact_key="iOS_18.0_22A100",
+        file_name="test.ipsw",
+        link="https://updates.cdn-apple.com/test.ipsw",
+        sha1="abc123",
+        last_run=123,
+        mirror_path=None,
+    )
+
+    ipsw_preview = preview_target_against_snapshot(
+        AdminStore.IPSW,
+        AdminActionKind.QUEUE_EXTRACT,
+        IpswTarget(artifact_key=ipsw_row.artifact_key, link=ipsw_row.link),
+        {f"{ipsw_row.artifact_key}::{ipsw_row.link}": ipsw_row},
+        {},
+    )
+
+    assert ipsw_preview.allowed is False
+    assert ipsw_preview.current_state == ArtifactProcessingState.SYMBOL_EXTRACTION_FAILED
+    assert ipsw_preview.resulting_state is None
+    assert ipsw_preview.row_label == "test.ipsw"
+    assert ipsw_preview.note == "mirror_path is required to queue extract"
+
+
 def test_validate_pending_batch_against_snapshot_reports_missing_rows() -> None:
     batch = PendingBatch(
         store=AdminStore.OTA,

--- a/tests/test_admin_actions.py
+++ b/tests/test_admin_actions.py
@@ -13,9 +13,11 @@ from symx.admin.actions import (
     WorkerDispatchStatus,
     bind_pending_batch,
     preview_action,
+    preview_target_against_snapshot,
     snapshot_generation_for_store,
+    validate_pending_batch_against_snapshot,
 )
-from symx.admin.db import SnapshotInfo
+from symx.admin.db import IpswSourceRow, OtaArtifactRow, SnapshotInfo
 from symx.model import ArtifactProcessingState
 
 
@@ -108,3 +110,72 @@ def test_apply_batch_request_rejects_boolean_integer_payloads() -> None:
             '{"store":"ota","action":"queue_mirror","snapshot_id":"ipsw-1__ota-2","base_generation":true,'
             '"reason":"retry mirror","targets":[{"ota_key":"ota-key"}]}'
         )
+
+
+def test_preview_target_against_snapshot_uses_snapshot_rows_and_blocks_missing_extract_path() -> None:
+    ipsw_row = IpswSourceRow(
+        last_modified="2024-09-03T12:34:56",
+        processing_state=ArtifactProcessingState.SYMBOL_EXTRACTION_FAILED,
+        platform="iOS",
+        version="18.0",
+        build="22A100",
+        artifact_key="iOS_18.0_22A100",
+        file_name="test.ipsw",
+        link="https://updates.cdn-apple.com/test.ipsw",
+        sha1="abc123",
+        last_run=123,
+        mirror_path="mirror/ipsw/iOS/18.0/22A100/test.ipsw",
+    )
+    ota_row = OtaArtifactRow(
+        last_run=456,
+        processing_state=ArtifactProcessingState.SYMBOL_EXTRACTION_FAILED,
+        platform="ios",
+        version="18.0",
+        build="22A100",
+        ota_key="ota-key",
+        artifact_id="ota-id",
+        url="https://updates.cdn-apple.com/test.zip",
+        hash="def456",
+        hash_algorithm="SHA-1",
+        download_path=None,
+    )
+
+    ipsw_preview = preview_target_against_snapshot(
+        AdminStore.IPSW,
+        AdminActionKind.QUEUE_EXTRACT,
+        IpswTarget(artifact_key=ipsw_row.artifact_key, link=ipsw_row.link),
+        {f"{ipsw_row.artifact_key}::{ipsw_row.link}": ipsw_row},
+        {},
+    )
+    ota_preview = preview_target_against_snapshot(
+        AdminStore.OTA,
+        AdminActionKind.QUEUE_EXTRACT,
+        OtaTarget(ota_key=ota_row.ota_key),
+        {},
+        {ota_row.ota_key: ota_row},
+    )
+
+    assert ipsw_preview.allowed is True
+    assert ipsw_preview.current_state == ArtifactProcessingState.SYMBOL_EXTRACTION_FAILED
+    assert ipsw_preview.resulting_state == ArtifactProcessingState.MIRRORED
+    assert ipsw_preview.row_label == "test.ipsw"
+    assert ota_preview.allowed is False
+    assert ota_preview.current_state == ArtifactProcessingState.SYMBOL_EXTRACTION_FAILED
+    assert ota_preview.resulting_state is None
+    assert ota_preview.row_label == "ota-id"
+    assert ota_preview.note == "download_path is required to queue extract"
+
+
+def test_validate_pending_batch_against_snapshot_reports_missing_rows() -> None:
+    batch = PendingBatch(
+        store=AdminStore.OTA,
+        action=AdminActionKind.QUEUE_EXTRACT,
+        targets=(OtaTarget(ota_key="missing-ota-key"),),
+        reason="retry extract",
+    )
+
+    issues = validate_pending_batch_against_snapshot(batch, {}, {})
+
+    assert len(issues) == 1
+    assert issues[0].target == "missing-ota-key"
+    assert issues[0].reason == "missing from current snapshot"

--- a/tests/test_admin_tui.py
+++ b/tests/test_admin_tui.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from rich.text import Text
 
+from symx.admin.actions import AdminActionKind, AdminStore, OtaTarget, PendingBatch
 from symx.admin.github import GithubRunInfo
 from symx.admin.tui import (
     AdminTui,
@@ -153,3 +154,75 @@ def test_format_ota_detail_includes_resolved_run_time() -> None:
     assert "last_run: #456" in detail
     assert "last_run_at: 2024-09-03 12:34Z" in detail
     assert "run_title: Extract OTA symbols" in detail
+
+
+def test_queue_selected_rejects_extract_batch_item_without_snapshot_download_path(tmp_path: Path, monkeypatch) -> None:
+    app = AdminTui(cache_dir=tmp_path)
+    row = OtaFailureRow(
+        last_run=456,
+        processing_state=ArtifactProcessingState.SYMBOL_EXTRACTION_FAILED,
+        platform="ios",
+        version="18.0",
+        build="22A100",
+        ota_key="ota-key",
+        artifact_id="ota-id",
+        url="https://updates.cdn-apple.com/test.zip",
+        hash="def456",
+        hash_algorithm="SHA-1",
+        download_path=None,
+    )
+    statuses: list[str] = []
+
+    app._active_table_id = "ota-failures"
+    app._selected_ota_row_key = row.ota_key
+    app._ota_rows_by_key = {row.ota_key: row}
+    app._all_ota_rows_by_key = {row.ota_key: row}
+    monkeypatch.setattr(app, "_set_status", lambda message: statuses.append(message))
+    monkeypatch.setattr(app, "_refresh_pending_batch", lambda: None)
+
+    app._queue_selected(AdminActionKind.QUEUE_EXTRACT)
+
+    assert app._pending_batch is None
+    assert statuses == ["Cannot add ota-key to queue extract batch: download_path is required to queue extract."]
+
+
+def test_action_apply_batch_rejects_pending_batch_invalid_for_current_snapshot(tmp_path: Path, monkeypatch) -> None:
+    app = AdminTui(cache_dir=tmp_path)
+    row = OtaFailureRow(
+        last_run=456,
+        processing_state=ArtifactProcessingState.SYMBOL_EXTRACTION_FAILED,
+        platform="ios",
+        version="18.0",
+        build="22A100",
+        ota_key="ota-key",
+        artifact_id="ota-id",
+        url="https://updates.cdn-apple.com/test.zip",
+        hash="def456",
+        hash_algorithm="SHA-1",
+        download_path=None,
+    )
+    statuses: list[str] = []
+    push_calls: list[tuple[object, ...]] = []
+
+    app._current_snapshot_info = SnapshotInfo(
+        snapshot_id="ipsw-101__ota-202",
+        created_at="2024-09-03T12:00:00+00:00",
+        workflow_run_id=1,
+        workflow_run_url=None,
+        ipsw_generation=101,
+        ota_generation=202,
+    )
+    app._all_ota_rows_by_key = {row.ota_key: row}
+    app._pending_batch = PendingBatch(
+        store=AdminStore.OTA,
+        action=AdminActionKind.QUEUE_EXTRACT,
+        targets=(OtaTarget(ota_key=row.ota_key),),
+        reason="",
+    )
+    monkeypatch.setattr(app, "_set_status", lambda message: statuses.append(message))
+    monkeypatch.setattr(app, "push_screen", lambda *args, **kwargs: push_calls.append(args))
+
+    app.action_apply_batch()
+
+    assert push_calls == []
+    assert statuses == ["Cannot apply pending batch: ota-key: download_path is required to queue extract"]


### PR DESCRIPTION
Up to now, the admin deferred validation of queue batches for extraction or mirror reruns to the workflow that applied the state changes. While this is not wrong, it is rather late feedback.

With this PR, the admin has 3 validation stages:

- in the TUI, when adding an artifact to the batch. This is the fastest feedback and should handle most cases.
- in the TUI, when a batch is applied. This should only be necessary if a batch was previously applied but failed in the workflow because a concurrent workflow updated the target metadata. In that case, a retry can validate against the refreshed metadata.
- in the workflow, as before, as a fallback.