### PR TITLE
fix: introduce an AEA preflight check...

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -75,7 +75,7 @@ Requirements:
 - `ipsw` installed and on `PATH`
 - executable `./symsorter` at the repository root
 
-For IPSW extraction, Symx also ships a vendored AEA PEM DB snapshot at `symx/ipsw/data/fcs-keys.json` and passes it to `ipsw` via `--pem-db` before `ipsw` falls back to live Apple FCS-key lookup. Refresh that file from upstream `ipsw/pkg/aea/data/fcs-keys.gz` when newly mirrored IPSWs start failing with AEA/FCS-key 403s on GitHub macOS runners.
+For IPSW extraction, Symx also ships a vendored AEA PEM DB snapshot at `symx/ipsw/data/fcs-keys.json` and passes it to `ipsw` via `--pem-db` before `ipsw` falls back to live Apple FCS-key lookup. Refresh that file from upstream `ipsw/pkg/aea/data/fcs-keys.gz` when newly mirrored IPSWs start failing with AEA/FCS-key 403s on GitHub macOS runners. Before the high-level `ipsw mount sys` / `ipsw extract --dyld` steps, Symx also does a small AEA preflight against the selected DMG member so failures can be classified as key-resolution problems earlier.
 
 In practice, the extraction paths are run on **macOS** in production because they rely on the `ipsw` toolchain, DMG mount flows, and the platform-specific `symsorter` binary.
 
@@ -119,6 +119,7 @@ What it does:
 - validates `ipsw` and `./symsorter`,
 - runs the IPSW extraction pipeline locally,
 - uses the vendored IPSW PEM DB snapshot before any live Apple FCS-key lookup,
+- performs an AEA preflight on the selected IPSW DMG member before the higher-level `ipsw` mount/extract helpers,
 - prints the output directory containing the symsorter result.
 
 ### OTA

--- a/symx/ipsw/extract.py
+++ b/symx/ipsw/extract.py
@@ -1,13 +1,26 @@
+import json
+import logging
+import plistlib
 import re
 import shutil
 import signal
 import subprocess
+import tempfile
+import zipfile
+from functools import lru_cache
 from pathlib import Path
-import logging
+from typing import Any, cast
+from urllib.parse import urlparse
 
 import sentry_sdk
 
-from symx.diagnostics import directory_data, format_command, subprocess_result_data, truncate_text
+from symx.diagnostics import (
+    decode_subprocess_output,
+    directory_data,
+    format_command,
+    subprocess_result_data,
+    truncate_text,
+)
 from symx.model import Arch
 from symx.tools import dyld_split, symsort
 from symx.ipsw.model import IpswPlatform
@@ -37,8 +50,111 @@ def _ipsw_command_data(
         "command": format_command(command),
         "stdout": truncate_text(stdout),
         "stderr": truncate_text(stderr),
+        "stderr_summary": _summarize_ipsw_stderr(stderr),
         "directories": [directory_data(directory) for directory in directories],
     }
+
+
+def _manifest_component_path(component: object) -> str | None:
+    if not isinstance(component, dict):
+        return None
+
+    component_dict = cast(dict[str, Any], component)
+    info = component_dict.get("Info")
+    if not isinstance(info, dict):
+        return None
+
+    info_dict = cast(dict[str, Any], info)
+    path = info_dict.get("Path")
+    if isinstance(path, str) and path:
+        return path
+    return None
+
+
+def inspect_ipsw_dmg_paths(ipsw_path: Path) -> dict[str, str | None]:
+    with zipfile.ZipFile(ipsw_path) as archive:
+        build_manifest_obj = plistlib.loads(archive.read("BuildManifest.plist"))
+
+    if not isinstance(build_manifest_obj, dict):
+        raise ValueError(f"Unexpected BuildManifest.plist structure in {ipsw_path}")
+
+    build_manifest = cast(dict[str, Any], build_manifest_obj)
+    build_identities_obj = build_manifest.get("BuildIdentities")
+    if not isinstance(build_identities_obj, list):
+        raise ValueError(f"BuildManifest.plist has no BuildIdentities list in {ipsw_path}")
+
+    build_identities = cast(list[object], build_identities_obj)
+    system_dmg: str | None = None
+    filesystem_dmgs: list[str] = []
+
+    for build_identity_obj in build_identities:
+        if not isinstance(build_identity_obj, dict):
+            continue
+
+        build_identity = cast(dict[str, Any], build_identity_obj)
+        manifest_obj = build_identity.get("Manifest")
+        if not isinstance(manifest_obj, dict):
+            continue
+
+        manifest = cast(dict[str, Any], manifest_obj)
+        if system_dmg is None:
+            system_dmg = _manifest_component_path(manifest.get("Cryptex1,SystemOS"))
+
+        filesystem_dmg = _manifest_component_path(manifest.get("OS"))
+        if filesystem_dmg is None:
+            continue
+
+        info_obj = build_identity.get("Info")
+        variant = None
+        if isinstance(info_obj, dict):
+            info = cast(dict[str, Any], info_obj)
+            variant_obj = info.get("Variant")
+            if isinstance(variant_obj, str):
+                variant = variant_obj
+        if variant is not None and "Recovery" in variant:
+            continue
+
+        if filesystem_dmg not in filesystem_dmgs:
+            filesystem_dmgs.append(filesystem_dmg)
+
+    filesystem_dmg = filesystem_dmgs[0] if len(filesystem_dmgs) == 1 else None
+    selected_dmg = system_dmg if system_dmg is not None else filesystem_dmg
+
+    return {
+        "system": system_dmg,
+        "filesystem": filesystem_dmg,
+        "selected": selected_dmg,
+    }
+
+
+def _extract_ipsw_member(ipsw_path: Path, member_name: str, output_path: Path) -> Path:
+    with zipfile.ZipFile(ipsw_path) as archive:
+        with archive.open(member_name) as src, output_path.open("wb") as dst:
+            shutil.copyfileobj(src, dst)
+    return output_path
+
+
+def _parse_fcs_key_url(output: str | bytes | None) -> str | None:
+    text = _strip_ansi(decode_subprocess_output(output))
+    if not text:
+        return None
+
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    for idx, line in enumerate(lines):
+        if line != _FCS_KEY_URL_LABEL:
+            continue
+        if idx + 1 < len(lines):
+            return lines[idx + 1]
+
+    return None
+
+
+def _fcs_key_id_from_url(url: str | None) -> str | None:
+    if not url:
+        return None
+    parsed = urlparse(url)
+    key_id = Path(parsed.path).name
+    return key_id or None
 
 
 def _compress_directory(directory: Path) -> Path:
@@ -115,6 +231,96 @@ class IpswExtractor:
             raise ValueError(f"IPSW path is expected to be a file: {ipsw_path}")
 
         self.ipsw_path = ipsw_path
+        self._aea_preflight_complete = False
+
+    def _ipsw_aea_preflight(self) -> None:
+        if self._aea_preflight_complete:
+            return
+
+        with sentry_sdk.start_span(op="ipsw.preflight.aea", name="IPSW AEA preflight") as span:
+            span.set_data("ipsw_path", str(self.ipsw_path))
+
+            try:
+                dmg_paths = inspect_ipsw_dmg_paths(self.ipsw_path)
+            except Exception as error:
+                span.set_data("preflight_error", f"failed to inspect IPSW DMG metadata: {error}")
+                logger.warning("Failed to inspect IPSW AEA metadata for %s: %s", self.ipsw_path.name, error)
+                self._aea_preflight_complete = True
+                return
+
+            span.set_data("ipsw_dmg_paths", dmg_paths)
+            selected_dmg = dmg_paths.get("selected")
+            if not isinstance(selected_dmg, str) or not selected_dmg.endswith(".aea"):
+                self._aea_preflight_complete = True
+                return
+
+            probe_data: dict[str, object] = {
+                "selected_dmg": selected_dmg,
+                "system_dmg": dmg_paths.get("system"),
+                "filesystem_dmg": dmg_paths.get("filesystem"),
+            }
+            pem_db_path = vendored_ipsw_pem_db_path()
+            if pem_db_path is not None:
+                probe_data["pem_db_path"] = str(pem_db_path)
+
+            with tempfile.TemporaryDirectory(suffix="_ipsw_aea_probe") as tmpdir:
+                temp_dir = Path(tmpdir)
+                extracted_aea = temp_dir / Path(selected_dmg).name
+
+                try:
+                    _extract_ipsw_member(self.ipsw_path, selected_dmg, extracted_aea)
+                except Exception as error:
+                    span.set_data("preflight_error", f"failed to extract AEA member {selected_dmg}: {error}")
+                    logger.warning(
+                        "Failed to extract IPSW AEA preflight member %s from %s: %s",
+                        selected_dmg,
+                        self.ipsw_path.name,
+                        error,
+                    )
+                    self._aea_preflight_complete = True
+                    return
+
+                info_command = ["ipsw", "--no-color", "fw", "aea", "--info", str(extracted_aea)]
+                info_result = subprocess.run(info_command, capture_output=True)
+                info_command_data = _ipsw_command_data(info_command, info_result.stdout, info_result.stderr, [temp_dir])
+                info_command_data.update(probe_data)
+                span.set_data("aea_info", info_command_data)
+                if info_result.returncode != 0:
+                    span.set_status("internal_error")
+                    summary = _summarize_ipsw_stderr(info_result.stderr) or "ipsw fw aea --info failed"
+                    raise IpswExtractError(f"IPSW AEA preflight failed for {self.ipsw_path}: {summary}")
+
+                fcs_key_url = _parse_fcs_key_url(info_result.stdout)
+                fcs_key_id = _fcs_key_id_from_url(fcs_key_url)
+                vendored_db_hit = False
+                if fcs_key_id is not None:
+                    vendored_db_hit = fcs_key_id in _vendored_ipsw_pem_db_keys()
+
+                probe_data["fcs_key_url"] = fcs_key_url
+                probe_data["fcs_key_id"] = fcs_key_id
+                probe_data["vendored_db_hit"] = vendored_db_hit
+                span.set_data("aea_probe", probe_data)
+
+                key_command = ["ipsw", "--no-color", "fw", "aea", "--key"]
+                if pem_db_path is not None:
+                    key_command.extend(["--pem-db", str(pem_db_path)])
+                key_command.append(str(extracted_aea))
+
+                key_result = subprocess.run(key_command, capture_output=True)
+                key_command_data = _ipsw_command_data(key_command, key_result.stdout, key_result.stderr, [temp_dir])
+                key_command_data.update(probe_data)
+                span.set_data("aea_key_probe", key_command_data)
+                if key_result.returncode != 0:
+                    span.set_status("internal_error")
+                    summary = _summarize_ipsw_stderr(key_result.stderr) or "ipsw fw aea --key failed"
+                    raise IpswExtractError(
+                        f"IPSW AEA preflight failed for {self.ipsw_path}: "
+                        f"selected_dmg={selected_dmg}; system_dmg={dmg_paths.get('system')}; "
+                        f"filesystem_dmg={dmg_paths.get('filesystem')}; fcs_key={fcs_key_id or '<unknown>'}; "
+                        f"vendored_db_hit={vendored_db_hit}; {summary}"
+                    )
+
+        self._aea_preflight_complete = True
 
     def symbols_dir(self) -> Path:
         return self.processing_dir / "symbols"
@@ -163,8 +369,10 @@ class IpswExtractor:
                 span.set_data("ipsw_extract", _ipsw_command_data(command, stdout, stderr, [self.processing_dir]))
                 if process.returncode != 0:
                     span.set_status("internal_error")
+                    stderr_summary = _summarize_ipsw_stderr(stderr)
+                    detail = f": {stderr_summary}" if stderr_summary else ""
                     raise IpswExtractError(
-                        f"ipsw extract failed for {self.ipsw_path} ({arch_label}) with exit code {process.returncode}"
+                        f"ipsw extract failed for {self.ipsw_path} ({arch_label}) with exit code {process.returncode}{detail}"
                     )
 
             _log_directory_contents(self.processing_dir)
@@ -180,6 +388,7 @@ class IpswExtractor:
             return extract_dir
 
     def run(self) -> Path:
+        self._ipsw_aea_preflight()
         with sentry_sdk.start_span(op="ipsw.extract.sys_image", name="Symsort sys image"):
             self._symsort_sys_image()
         with sentry_sdk.start_span(op="ipsw.extract.dsc", name=f"Extract+split+symsort DSC ({self.platform})"):
@@ -273,8 +482,16 @@ class IpswExtractor:
             if mount_point:
                 mount_span.set_data("mount_point", str(mount_point))
             elif mount_output_lines:
+                mount_output = "\n".join(mount_output_lines)
+                mount_summary = _summarize_ipsw_stderr(mount_output)
                 mount_span.set_data("mount_output_preview", mount_output_lines[:20])
-                logger.warning("Could not determine sys image mount point for %s", self.ipsw_path.name)
+                mount_span.set_data("mount_output_summary", mount_summary)
+                if mount_summary:
+                    logger.warning(
+                        "Could not determine sys image mount point for %s: %s", self.ipsw_path.name, mount_summary
+                    )
+                else:
+                    logger.warning("Could not determine sys image mount point for %s", self.ipsw_path.name)
 
         try:
             # symsort the entire sys mount-point
@@ -282,14 +499,15 @@ class IpswExtractor:
                 self._symsort(mount_point, ignore_errors=True)
         finally:
             # SIGINT the mount process and wait for it to unmount
-            mount_proc.send_signal(signal.SIGINT)
-            try:
-                # Wait for process to cleanly unmount (timeout after 60 seconds)
-                mount_proc.wait(timeout=60)
-            except subprocess.TimeoutExpired:
-                logger.warning("Mount process did not terminate after SIGINT, killing it")
-                mount_proc.kill()
-                mount_proc.wait()
+            if mount_proc.poll() is None:
+                mount_proc.send_signal(signal.SIGINT)
+                try:
+                    # Wait for process to cleanly unmount (timeout after 60 seconds)
+                    mount_proc.wait(timeout=60)
+                except subprocess.TimeoutExpired:
+                    logger.warning("Mount process did not terminate after SIGINT, killing it")
+                    mount_proc.kill()
+                    mount_proc.wait()
 
             # Clean up mount point directory if it still exists (in case unmount failed)
             if mount_point and mount_point.exists():
@@ -375,6 +593,65 @@ def find_extraction_dir(processing_dir: Path) -> Path | None:
                 extra={"directory": item},
             )
             return item
+    return None
+
+
+_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*m")
+_LEADING_IPSW_GLYPH_RE = re.compile(r"^\s*[•⨯]\s*")
+_ERROR_SUMMARY_MARKERS = (
+    "error",
+    "failed",
+    "invalid",
+    "not found",
+    "unable",
+    "unknown flag",
+    "must specify",
+)
+_IGNORED_IPSW_HELP_PREFIXES = ("Usage:", "Aliases:", "Examples:", "Flags:", "Global Flags:")
+_FCS_KEY_URL_LABEL = "[com.apple.wkms.fcs-key-url]:"
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_ESCAPE_RE.sub("", text)
+
+
+def _normalize_ipsw_output_line(line: str) -> str:
+    return _LEADING_IPSW_GLYPH_RE.sub("", line).strip()
+
+
+@lru_cache(maxsize=1)
+def _vendored_ipsw_pem_db_keys() -> frozenset[str]:
+    pem_db_path = vendored_ipsw_pem_db_path()
+    if pem_db_path is None:
+        return frozenset()
+
+    with pem_db_path.open() as handle:
+        raw_data_obj = json.load(handle)
+
+    if not isinstance(raw_data_obj, dict):
+        raise ValueError(f"Vendored IPSW PEM DB must be a JSON object: {pem_db_path}")
+
+    raw_data = cast(dict[object, object], raw_data_obj)
+    return frozenset(str(key) for key in raw_data)
+
+
+def _summarize_ipsw_stderr(stderr: str | bytes | None) -> str | None:
+    text = decode_subprocess_output(stderr)
+    if not text:
+        return None
+
+    stripped = _strip_ansi(text)
+    lines = [_normalize_ipsw_output_line(line) for line in stripped.splitlines() if line.strip()]
+    if not lines:
+        return None
+
+    for line in reversed(lines):
+        if line.startswith(_IGNORED_IPSW_HELP_PREFIXES):
+            continue
+        lowered = line.lower()
+        if any(marker in lowered for marker in _ERROR_SUMMARY_MARKERS):
+            return line
+
     return None
 
 

--- a/tests/test_extract_utils.py
+++ b/tests/test_extract_utils.py
@@ -5,6 +5,8 @@ These are pure functions or functions with minimal I/O that support
 the OTA and IPSW extraction workflows.
 """
 
+import json
+import plistlib
 import subprocess
 import tempfile
 import zipfile
@@ -21,6 +23,7 @@ from symx.ipsw.extract import (
     IpswExtractor,
     find_extraction_dir,
     generate_bundle_id,
+    inspect_ipsw_dmg_paths,
     map_platform_to_prefix,
 )
 from subprocess import CompletedProcess
@@ -105,6 +108,36 @@ def test_find_extraction_dir_returns_first_match() -> None:
 
 
 # --- IPSW diagnostics tests ---
+
+
+def test_inspect_ipsw_dmg_paths_prefers_systemos_and_skips_recovery_filesystem(tmp_path: Path) -> None:
+    ipsw_path = tmp_path / "test.ipsw"
+    build_manifest = {
+        "BuildIdentities": [
+            {
+                "Manifest": {
+                    "Cryptex1,SystemOS": {"Info": {"Path": "system.dmg.aea"}},
+                    "OS": {"Info": {"Path": "filesystem.dmg.aea"}},
+                },
+                "Info": {"Variant": "Customer Erase Install (IPSW)"},
+            },
+            {
+                "Manifest": {
+                    "OS": {"Info": {"Path": "recovery.dmg"}},
+                },
+                "Info": {"Variant": "Recovery Customer Erase Install (IPSW)"},
+            },
+        ]
+    }
+
+    with zipfile.ZipFile(ipsw_path, "w") as archive:
+        archive.writestr("BuildManifest.plist", plistlib.dumps(build_manifest))
+
+    assert inspect_ipsw_dmg_paths(ipsw_path) == {
+        "system": "system.dmg.aea",
+        "filesystem": "filesystem.dmg.aea",
+        "selected": "system.dmg.aea",
+    }
 
 
 def _make_ipsw_extractor(tmp_path: Path) -> IpswExtractor:
@@ -257,6 +290,205 @@ def test_ipsw_symsort_sys_image_passes_vendored_pem_db_when_available(
         ) -> None:
             commands.append(command)
             self.stdout = FakeStdout([f"Press Ctrl+C to unmount '{mount_point}'\n", ""])
+
+        def send_signal(self, sig: int) -> None:
+            return None
+
+        def wait(self, timeout: int | None = None) -> int:
+            return 0
+
+        def kill(self) -> None:
+            return None
+
+    monkeypatch.setattr("symx.ipsw.extract.vendored_ipsw_pem_db_path", lambda: pem_db)
+    monkeypatch.setattr("symx.ipsw.extract.subprocess.Popen", FakePopen)
+    monkeypatch.setattr(
+        IpswExtractor,
+        "_symsort",
+        lambda self, split_dir, ignore_errors=False: symsort_calls.append((split_dir, ignore_errors)),
+    )
+
+    extractor._symsort_sys_image()
+
+    assert commands == [["ipsw", "mount", "sys", str(extractor.ipsw_path), "-V", "--pem-db", str(pem_db)]]
+    assert symsort_calls == [(mount_point, True)]
+
+
+def test_ipsw_aea_preflight_classifies_missing_key_failures(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    processing_dir = tmp_path / "processing"
+    processing_dir.mkdir()
+    ipsw_path = tmp_path / "test.ipsw"
+    build_manifest = {
+        "BuildIdentities": [
+            {
+                "Manifest": {
+                    "Cryptex1,SystemOS": {"Info": {"Path": "system.dmg.aea"}},
+                    "OS": {"Info": {"Path": "filesystem.dmg.aea"}},
+                },
+                "Info": {"Variant": "Customer Erase Install (IPSW)"},
+            }
+        ]
+    }
+
+    with zipfile.ZipFile(ipsw_path, "w") as archive:
+        archive.writestr("BuildManifest.plist", plistlib.dumps(build_manifest))
+        archive.writestr("system.dmg.aea", b"dummy")
+
+    extractor = IpswExtractor(IpswPlatform.IPADOS, "iPad15,7_26.4.2_23E261_Restore.ipsw", processing_dir, ipsw_path)
+    pem_db = tmp_path / "fcs-keys.json"
+    pem_db.write_text(json.dumps({"known-key": "known-value"}))
+
+    def fake_run(command: list[str], capture_output: bool = False) -> CompletedProcess[bytes]:
+        if "--info" in command:
+            return CompletedProcess(
+                args=command,
+                returncode=0,
+                stdout=(
+                    "[com.apple.wkms.fcs-key-url]:\nhttps://wkms-public.apple.com/fcs-keys/missing-key=\n"
+                ).encode(),
+                stderr=b"",
+            )
+
+        return CompletedProcess(
+            args=command,
+            returncode=1,
+            stdout=b"",
+            stderr=b"\xe2\xa8\xaf failed to HPKE decrypt fcs-key: failed to connect to fcs-key URL: 403 Forbidden\n",
+        )
+
+    monkeypatch.setattr("symx.ipsw.extract.vendored_ipsw_pem_db_path", lambda: pem_db)
+    monkeypatch.setattr("symx.ipsw.extract._vendored_ipsw_pem_db_keys", lambda: frozenset({"known-key"}))
+    monkeypatch.setattr("symx.ipsw.extract.subprocess.run", fake_run)
+
+    with pytest.raises(IpswExtractError, match="IPSW AEA preflight failed") as exc_info:
+        extractor._ipsw_aea_preflight()
+
+    message = str(exc_info.value)
+    assert "selected_dmg=system.dmg.aea" in message
+    assert "system_dmg=system.dmg.aea" in message
+    assert "filesystem_dmg=filesystem.dmg.aea" in message
+    assert "fcs_key=missing-key=" in message
+    assert "vendored_db_hit=False" in message
+    assert "failed to HPKE decrypt fcs-key: failed to connect to fcs-key URL: 403 Forbidden" in message
+
+
+def test_ipsw_extract_dsc_includes_stderr_summary_when_available(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    extractor = _make_ipsw_extractor(tmp_path)
+
+    class FakePopen:
+        def __init__(self, command: list[str], stdout: object = None, stderr: object = None) -> None:
+            self.command = command
+            self.returncode = 1
+
+        def __enter__(self) -> "FakePopen":
+            return self
+
+        def __exit__(self, exc_type: object, exc: object, tb: object) -> bool:
+            return False
+
+        def communicate(self, timeout: int | None = None) -> tuple[bytes, bytes]:
+            return (
+                b"extract stdout",
+                b"Usage:\n  ipsw extract <IPSW/OTA | URL> [flags]\n\nError: failed to mount DMG /tmp/test.dmg",
+            )
+
+        def kill(self) -> None:
+            self.returncode = -9
+
+    monkeypatch.setattr("symx.ipsw.extract.subprocess.Popen", FakePopen)
+
+    with pytest.raises(IpswExtractError, match="failed to mount DMG /tmp/test.dmg") as exc_info:
+        extractor._ipsw_extract_dsc()
+
+    message = str(exc_info.value)
+    assert message == (
+        f"ipsw extract failed for {extractor.ipsw_path} (default) with exit code 1: "
+        "Error: failed to mount DMG /tmp/test.dmg"
+    )
+
+
+def test_ipsw_extract_dsc_passes_vendored_pem_db_when_available(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    extractor = _make_ipsw_extractor(tmp_path)
+    pem_db = tmp_path / "fcs-keys.json"
+    pem_db.write_text("{}")
+    expected_extract_dir = extractor.processing_dir / "23E261__iPad15,7"
+    expected_extract_dir.mkdir()
+    commands: list[list[str]] = []
+
+    class FakePopen:
+        def __init__(self, command: list[str], stdout: object = None, stderr: object = None) -> None:
+            commands.append(command)
+            self.command = command
+            self.returncode = 0
+
+        def __enter__(self) -> "FakePopen":
+            return self
+
+        def __exit__(self, exc_type: object, exc: object, tb: object) -> bool:
+            return False
+
+        def communicate(self, timeout: int | None = None) -> tuple[bytes, bytes]:
+            return b"extract stdout", b"extract stderr"
+
+        def kill(self) -> None:
+            self.returncode = -9
+
+    monkeypatch.setattr("symx.ipsw.extract.vendored_ipsw_pem_db_path", lambda: pem_db)
+    monkeypatch.setattr("symx.ipsw.extract.subprocess.Popen", FakePopen)
+
+    assert extractor._ipsw_extract_dsc() == expected_extract_dir
+    assert commands == [
+        [
+            "ipsw",
+            "extract",
+            str(extractor.ipsw_path),
+            "-d",
+            "-o",
+            str(extractor.processing_dir),
+            "-V",
+            "--pem-db",
+            str(pem_db),
+        ]
+    ]
+
+
+def test_ipsw_symsort_sys_image_passes_vendored_pem_db_when_available(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    extractor = _make_ipsw_extractor(tmp_path)
+    pem_db = tmp_path / "fcs-keys.json"
+    pem_db.write_text("{}")
+    mount_point = tmp_path / "mount-point"
+    mount_point.mkdir()
+    commands: list[list[str]] = []
+    symsort_calls: list[tuple[Path, bool]] = []
+
+    class FakeStdout:
+        def __init__(self, lines: list[str]) -> None:
+            self._lines = iter(lines)
+
+        def readline(self) -> str:
+            return next(self._lines, "")
+
+    class FakePopen:
+        def __init__(
+            self,
+            command: list[str],
+            stdout: object = None,
+            stderr: object = None,
+            bufsize: int | None = None,
+            text: bool | None = None,
+        ) -> None:
+            commands.append(command)
+            self.stdout = FakeStdout([f"Press Ctrl+C to unmount '{mount_point}'\n", ""])
+            self.returncode = 0
+
+        def poll(self) -> int | None:
+            return None
 
         def send_signal(self, sig: int) -> None:
             return None

--- a/tests/test_extract_utils.py
+++ b/tests/test_extract_utils.py
@@ -290,6 +290,10 @@ def test_ipsw_symsort_sys_image_passes_vendored_pem_db_when_available(
         ) -> None:
             commands.append(command)
             self.stdout = FakeStdout([f"Press Ctrl+C to unmount '{mount_point}'\n", ""])
+            self.returncode = 0
+
+        def poll(self) -> int | None:
+            return None
 
         def send_signal(self, sig: int) -> None:
             return None
@@ -408,109 +412,6 @@ def test_ipsw_extract_dsc_includes_stderr_summary_when_available(
         "Error: failed to mount DMG /tmp/test.dmg"
     )
 
-
-def test_ipsw_extract_dsc_passes_vendored_pem_db_when_available(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    extractor = _make_ipsw_extractor(tmp_path)
-    pem_db = tmp_path / "fcs-keys.json"
-    pem_db.write_text("{}")
-    expected_extract_dir = extractor.processing_dir / "23E261__iPad15,7"
-    expected_extract_dir.mkdir()
-    commands: list[list[str]] = []
-
-    class FakePopen:
-        def __init__(self, command: list[str], stdout: object = None, stderr: object = None) -> None:
-            commands.append(command)
-            self.command = command
-            self.returncode = 0
-
-        def __enter__(self) -> "FakePopen":
-            return self
-
-        def __exit__(self, exc_type: object, exc: object, tb: object) -> bool:
-            return False
-
-        def communicate(self, timeout: int | None = None) -> tuple[bytes, bytes]:
-            return b"extract stdout", b"extract stderr"
-
-        def kill(self) -> None:
-            self.returncode = -9
-
-    monkeypatch.setattr("symx.ipsw.extract.vendored_ipsw_pem_db_path", lambda: pem_db)
-    monkeypatch.setattr("symx.ipsw.extract.subprocess.Popen", FakePopen)
-
-    assert extractor._ipsw_extract_dsc() == expected_extract_dir
-    assert commands == [
-        [
-            "ipsw",
-            "extract",
-            str(extractor.ipsw_path),
-            "-d",
-            "-o",
-            str(extractor.processing_dir),
-            "-V",
-            "--pem-db",
-            str(pem_db),
-        ]
-    ]
-
-
-def test_ipsw_symsort_sys_image_passes_vendored_pem_db_when_available(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    extractor = _make_ipsw_extractor(tmp_path)
-    pem_db = tmp_path / "fcs-keys.json"
-    pem_db.write_text("{}")
-    mount_point = tmp_path / "mount-point"
-    mount_point.mkdir()
-    commands: list[list[str]] = []
-    symsort_calls: list[tuple[Path, bool]] = []
-
-    class FakeStdout:
-        def __init__(self, lines: list[str]) -> None:
-            self._lines = iter(lines)
-
-        def readline(self) -> str:
-            return next(self._lines, "")
-
-    class FakePopen:
-        def __init__(
-            self,
-            command: list[str],
-            stdout: object = None,
-            stderr: object = None,
-            bufsize: int | None = None,
-            text: bool | None = None,
-        ) -> None:
-            commands.append(command)
-            self.stdout = FakeStdout([f"Press Ctrl+C to unmount '{mount_point}'\n", ""])
-            self.returncode = 0
-
-        def poll(self) -> int | None:
-            return None
-
-        def send_signal(self, sig: int) -> None:
-            return None
-
-        def wait(self, timeout: int | None = None) -> int:
-            return 0
-
-        def kill(self) -> None:
-            return None
-
-    monkeypatch.setattr("symx.ipsw.extract.vendored_ipsw_pem_db_path", lambda: pem_db)
-    monkeypatch.setattr("symx.ipsw.extract.subprocess.Popen", FakePopen)
-    monkeypatch.setattr(
-        IpswExtractor,
-        "_symsort",
-        lambda self, split_dir, ignore_errors=False: symsort_calls.append((split_dir, ignore_errors)),
-    )
-
-    extractor._symsort_sys_image()
-
-    assert commands == [["ipsw", "mount", "sys", str(extractor.ipsw_path), "-V", "--pem-db", str(pem_db)]]
-    assert symsort_calls == [(mount_point, True)]
 
 
 def test_ipsw_split_raises_detailed_error_when_split_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_extract_utils.py
+++ b/tests/test_extract_utils.py
@@ -413,7 +413,6 @@ def test_ipsw_extract_dsc_includes_stderr_summary_when_available(
     )
 
 
-
 def test_ipsw_split_raises_detailed_error_when_split_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     extractor = _make_ipsw_extractor(tmp_path)
     extract_dir = extractor.processing_dir / "23E261__iPad15,7"


### PR DESCRIPTION
...which allows better failure classification when we run higher-level features like `ipsw mount sys`. The latter does a lot of work, each with different failure modes, but resulting in a failure to mount an image, which isn't the root cause.

This change introduces checks for AEA/FCS preconditions before we run `ipsw mount sys`, enabling us to provide much higher-quality Sentry error reports and logs when the root cause is related to AEA/FCS key resolution.