### PR TITLE
fix: parallelize OTA meta update

### DIFF
--- a/symx/ota/meta.py
+++ b/symx/ota/meta.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import subprocess
+from concurrent.futures import ThreadPoolExecutor
 
 import sentry_sdk
 import sentry_sdk.metrics
@@ -67,27 +68,39 @@ def parse_download_meta_output(
             )
 
 
+def _download_meta_job(job: tuple[str, bool]) -> OtaMetaData:
+    platform, beta = job
+    label = f"{platform} (beta)" if beta else platform
+
+    with sentry_sdk.start_span(op="subprocess.ipsw_download_meta", name=f"Fetch OTA meta for {label}") as span:
+        span.set_data("platform", platform)
+        span.set_data("beta", beta)
+        logger.info("Downloading OTA meta for %s%s", platform, " (beta)" if beta else "")
+        cmd = [
+            "ipsw",
+            "download",
+            "ota",
+            "--platform",
+            platform,
+            "--urls",
+            "--json",
+        ]
+        if beta:
+            cmd.append("--beta")
+
+        result = subprocess.run(cmd, capture_output=True)
+        meta: OtaMetaData = {}
+        parse_download_meta_output(platform, result, meta, beta)
+        return meta
+
+
 def retrieve_current_meta() -> OtaMetaData:
     meta: OtaMetaData = {}
-    for platform in PLATFORMS:
-        with sentry_sdk.start_span(op="subprocess.ipsw_download_meta", name=f"Fetch OTA meta for {platform}") as span:
-            span.set_data("platform", platform)
-            logger.info("Downloading OTA meta for %s", platform)
-            cmd = [
-                "ipsw",
-                "download",
-                "ota",
-                "--platform",
-                platform,
-                "--urls",
-                "--json",
-            ]
+    jobs = [(platform, beta) for platform in PLATFORMS for beta in (False, True)]
 
-            parse_download_meta_output(platform, subprocess.run(cmd, capture_output=True), meta, False)
-
-            beta_cmd = cmd.copy()
-            beta_cmd.append("--beta")
-            parse_download_meta_output(platform, subprocess.run(beta_cmd, capture_output=True), meta, True)
+    with ThreadPoolExecutor(max_workers=len(jobs)) as executor:
+        for job_meta in executor.map(_download_meta_job, jobs):
+            meta.update(job_meta)
 
     sentry_sdk.metrics.distribution("ota.meta_sync.total_artifacts", len(meta))
     return meta

--- a/tests/test_ota_meta_parsing.py
+++ b/tests/test_ota_meta_parsing.py
@@ -4,10 +4,12 @@ Tests for OTA metadata parsing from ipsw command output.
 
 import json
 import subprocess
+import threading
+import time
 
 from symx.model import ArtifactProcessingState
 from symx.ota.model import OtaMetaData
-from symx.ota.meta import parse_download_meta_output
+from symx.ota.meta import parse_download_meta_output, retrieve_current_meta
 
 
 def make_completed_process(
@@ -171,3 +173,52 @@ def test_parse_download_meta_output_multiple_artifacts() -> None:
     assert len(meta) == 2
     assert "a" * 40 in meta
     assert "b" * 40 in meta
+
+
+def test_retrieve_current_meta_fetches_all_platform_variants_in_parallel_and_preserves_order(monkeypatch) -> None:
+    platforms = ["ios", "watchos", "tvos"]
+    monkeypatch.setattr("symx.ota.meta.PLATFORMS", platforms)
+
+    release_id = "a" * 40
+    beta_id = "b" * 40
+    active = 0
+    max_active = 0
+    active_lock = threading.Lock()
+
+    def fake_run(cmd: list[str], capture_output: bool = False) -> subprocess.CompletedProcess[bytes]:
+        assert capture_output is True
+        platform = cmd[cmd.index("--platform") + 1]
+        beta = "--beta" in cmd
+
+        nonlocal active, max_active
+        with active_lock:
+            active += 1
+            max_active = max(max_active, active)
+
+        time.sleep(0.05)
+
+        try:
+            artifact_id = beta_id if beta else release_id
+            payload = [
+                {
+                    "url": f"https://updates.apple.com/{artifact_id}.zip",
+                    "build": f"{platform}-{'beta' if beta else 'release'}",
+                    "version": "17.0",
+                    "hash": f"{platform}-{'beta' if beta else 'release'}",
+                    "hash_algorithm": "SHA-1",
+                }
+            ]
+            return make_completed_process(stdout=json.dumps(payload).encode())
+        finally:
+            with active_lock:
+                active -= 1
+
+    monkeypatch.setattr("symx.ota.meta.subprocess.run", fake_run)
+
+    meta = retrieve_current_meta()
+
+    assert max_active > 1
+    assert meta[release_id].platform == "tvos"
+    assert meta[release_id].build == "tvos-release"
+    assert meta[f"{beta_id}_beta"].platform == "tvos"
+    assert meta[f"{beta_id}_beta"].build == "tvos-beta"


### PR DESCRIPTION
Use `ThreadPoolExecutor` over the metadata sync for OTAs, which shaves off ~80% in practice for very little cost. Of course, this is only true for `symx ota mirror` runs without the actual mirroring (and the workflow itself has much more variability than this optimizes).