### PR TITLE
chore(ci): add bitrise runner matrix for macOS workflows

### DIFF
--- a/.github/workflows/symx-runner-macos.yml
+++ b/.github/workflows/symx-runner-macos.yml
@@ -24,7 +24,10 @@ on:
 jobs:
   symx-macos-job:
     name: ${{ inputs.job_name }}
-    runs-on: ["ghcr.io/cirruslabs/macos-runner:sequoia", "runner_group_id:10"]
+    runs-on: ${{ matrix.runner_provider == 'bitrise' && fromJSON('["bitrise_pool_name:tahoe"]') || fromJSON('["ghcr.io/cirruslabs/macos-runner:sequoia,runner_concurrency_group=10"]') }}
+    strategy:
+      matrix:
+        runner_provider: [cirrus, bitrise]
     permissions:
       actions: "read"
       contents: "read"

--- a/.github/workflows/test-bitrise-runner.yml
+++ b/.github/workflows/test-bitrise-runner.yml
@@ -1,0 +1,23 @@
+name: Test Bitrise Runner
+permissions:
+  actions: read
+  contents: read
+  id-token: write
+
+on:
+  workflow_dispatch:
+    inputs:
+      symx_run:
+        description: "symx command to run (e.g. 'ipsw extract -t 315 -s gcs://...')"
+        required: false
+        default: "ipsw extract -t 60 -s ${{ vars.SYMX_STORE }}"
+
+jobs:
+  call-reusable-workflow:
+    uses: ./.github/workflows/symx-runner-macos.yml
+    with:
+      job_name: Test Bitrise Runner
+      symx_step: Test Bitrise
+      symx_run: ${{ inputs.symx_run }}
+    secrets:
+      SENTRY_DSN: ${{ secrets.SENTRY_DSN }}


### PR DESCRIPTION
## Summary
- Add Bitrise as a second macOS runner provider alongside Cirrus via a strategy matrix in `symx-runner-macos.yml`
- Include a `workflow_dispatch` test workflow for manual validation

## Test plan
- [ ] Trigger test workflow manually on the fork to confirm Bitrise runner picks up the job
- [ ] Verify Cirrus runner still works in parallel

🤖 Generated with [Claude Code](https://claude.com/claude-code)