### PR TITLE
chore: Run CI on bitrise

### DIFF
--- a/.github/workflows/symx-runner-macos.yml
+++ b/.github/workflows/symx-runner-macos.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   symx-macos-job:
     name: ${{ inputs.job_name }}
-    runs-on: ["ghcr.io/cirruslabs/macos-runner:sequoia", "runner_group_id:10"]
+    runs-on: ["bitrise_pool_name:tahoe"]
     permissions:
       actions: "read"
       contents: "read"


### PR DESCRIPTION
Updates scheduled macOS jobs to run on bitrise `tahoe` pool using M4 Large runners (should have more than 100GB available)