### PR TITLE
fix: drain stdout pipe to `ipsw mount` on teardown

### DIFF
--- a/symx/ipsw/extract.py
+++ b/symx/ipsw/extract.py
@@ -4,9 +4,13 @@ import plistlib
 import re
 import shutil
 import signal
+import stat
 import subprocess
 import tempfile
 import zipfile
+from collections.abc import Generator
+from contextlib import contextmanager
+from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, cast
@@ -27,11 +31,89 @@ from symx.ipsw.model import IpswPlatform
 
 logger = logging.getLogger(__name__)
 
-mount_point_re = re.compile(r".*Press Ctrl\+C to unmount '(.*)'")
-extracted_mount_artifact_re = re.compile(r"^Extracted (.+?)(?: from .*)?$")
+_MOUNT_POINT_RE = re.compile(r".*Press Ctrl\+C to unmount '(.*)'")
+_EXTRACTED_MOUNT_ARTIFACT_RE = re.compile(r"^Extracted (.+?)(?: from .*)?$")
+_SYMSORTER_SORTED_DEBUG_FILES_RE = re.compile(r"^Sorted (\d+) debug files$")
+_SYMSORTER_CREATED_SOURCE_BUNDLES_RE = re.compile(r"^Created (\d+) source bundles$")
+_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*m")
+_LEADING_IPSW_GLYPH_RE = re.compile(r"^\s*[•⨯]\s*")
 
-
+_SYS_MOUNT_CLEANUP_TIMEOUT_SECONDS = 60
+_RESERVED_PROCESSING_DIR_NAMES = frozenset({"split_out", "symbols", "sys_mount"})
+_ERROR_SUMMARY_MARKERS = (
+    "error",
+    "failed",
+    "invalid",
+    "not found",
+    "unable",
+    "unknown flag",
+    "must specify",
+)
+_IGNORED_IPSW_HELP_PREFIXES = ("Usage:", "Aliases:", "Examples:", "Flags:", "Global Flags:")
+_FCS_KEY_URL_LABEL = "[com.apple.wkms.fcs-key-url]:"
 _VENDORED_PEM_DB = Path(__file__).resolve().parent / "data" / "fcs-keys.json"
+
+
+@dataclass(frozen=True)
+class DirectoryTreeStats:
+    path: str
+    exists: bool
+    is_dir: bool
+    file_count: int = 0
+    total_file_size_bytes: int = 0
+    directory_count: int = 0
+    symlink_count: int = 0
+    other_entry_count: int = 0
+    error_count: int = 0
+
+    def to_span_data(self) -> dict[str, object]:
+        data: dict[str, object] = {
+            "path": self.path,
+            "exists": self.exists,
+            "is_dir": self.is_dir,
+        }
+        if not self.is_dir:
+            return data
+
+        data.update(
+            {
+                "file_count": self.file_count,
+                "total_file_size_bytes": self.total_file_size_bytes,
+                "directory_count": self.directory_count,
+                "symlink_count": self.symlink_count,
+                "other_entry_count": self.other_entry_count,
+            }
+        )
+        if self.error_count:
+            data["error_count"] = self.error_count
+        return data
+
+
+@dataclass(frozen=True)
+class DirectoryTreeStatsDelta:
+    file_count_delta: int
+    total_file_size_bytes_delta: int
+    directory_count_delta: int
+    symlink_count_delta: int
+    other_entry_count_delta: int
+
+    def to_span_data(self) -> dict[str, int]:
+        return {
+            "file_count_delta": self.file_count_delta,
+            "total_file_size_bytes_delta": self.total_file_size_bytes_delta,
+            "directory_count_delta": self.directory_count_delta,
+            "symlink_count_delta": self.symlink_count_delta,
+            "other_entry_count_delta": self.other_entry_count_delta,
+        }
+
+
+@dataclass(frozen=True)
+class SysImageMount:
+    process: subprocess.Popen[str]
+    requested_mount_point: Path
+    active_mount_point: Path | None
+    extracted_artifact_paths: list[Path]
+    error: str | None = None
 
 
 def vendored_ipsw_pem_db_path() -> Path | None:
@@ -54,6 +136,190 @@ def _ipsw_command_data(
         "stderr_summary": _summarize_ipsw_stderr(stderr),
         "directories": [directory_data(directory) for directory in directories],
     }
+
+
+def _output_line_count(output: str | bytes | None) -> int:
+    text = decode_subprocess_output(output)
+    if not text:
+        return 0
+    return len(text.splitlines())
+
+
+def _directory_tree_stats(directory: Path) -> DirectoryTreeStats:
+    exists = directory.exists()
+    is_dir = directory.is_dir()
+    if not is_dir:
+        return DirectoryTreeStats(path=str(directory), exists=exists, is_dir=is_dir)
+
+    file_count = 0
+    total_file_size_bytes = 0
+    directory_count = 0
+    symlink_count = 0
+    other_entry_count = 0
+    error_count = 0
+    seen_files: set[tuple[int, int]] = set()
+    stack = [directory]
+
+    while stack:
+        current = stack.pop()
+        try:
+            entries = list(current.iterdir())
+        except OSError:
+            error_count += 1
+            continue
+
+        for entry in entries:
+            try:
+                entry_stat = entry.lstat()
+            except OSError:
+                error_count += 1
+                continue
+
+            mode = entry_stat.st_mode
+            if stat.S_ISDIR(mode):
+                directory_count += 1
+                stack.append(entry)
+            elif stat.S_ISREG(mode):
+                file_key = (entry_stat.st_dev, entry_stat.st_ino)
+                if file_key in seen_files:
+                    continue
+                seen_files.add(file_key)
+                file_count += 1
+                total_file_size_bytes += entry_stat.st_size
+            elif stat.S_ISLNK(mode):
+                symlink_count += 1
+            else:
+                other_entry_count += 1
+
+    return DirectoryTreeStats(
+        path=str(directory),
+        exists=exists,
+        is_dir=is_dir,
+        file_count=file_count,
+        total_file_size_bytes=total_file_size_bytes,
+        directory_count=directory_count,
+        symlink_count=symlink_count,
+        other_entry_count=other_entry_count,
+        error_count=error_count,
+    )
+
+
+def _directory_tree_delta(before: DirectoryTreeStats, after: DirectoryTreeStats) -> DirectoryTreeStatsDelta:
+    return DirectoryTreeStatsDelta(
+        file_count_delta=after.file_count - before.file_count,
+        total_file_size_bytes_delta=after.total_file_size_bytes - before.total_file_size_bytes,
+        directory_count_delta=after.directory_count - before.directory_count,
+        symlink_count_delta=after.symlink_count - before.symlink_count,
+        other_entry_count_delta=after.other_entry_count - before.other_entry_count,
+    )
+
+
+def _parse_symsorter_summary(stdout: str | bytes | None, stderr: str | bytes | None) -> dict[str, int]:
+    summary: dict[str, int] = {}
+    for line in decode_subprocess_output(stdout).splitlines():
+        if match := _SYMSORTER_SORTED_DEBUG_FILES_RE.match(line):
+            summary["sorted_debug_files"] = int(match.group(1))
+        elif match := _SYMSORTER_CREATED_SOURCE_BUNDLES_RE.match(line):
+            summary["created_source_bundles"] = int(match.group(1))
+
+    stderr_text = decode_subprocess_output(stderr)
+    duplicate_warning_count = stderr_text.count("already exists")
+    if duplicate_warning_count:
+        summary["duplicate_debug_file_warnings"] = duplicate_warning_count
+
+    return summary
+
+
+def _record_mount_process_output(
+    span: Any,
+    stdout_key: str,
+    stderr_key: str,
+    stdout: str | bytes | None,
+    stderr: str | bytes | None,
+) -> None:
+    span.set_data(stdout_key, truncate_text(stdout))
+    span.set_data(stderr_key, truncate_text(stderr))
+    span.set_data(f"{stdout_key}_line_count", _output_line_count(stdout))
+    span.set_data(f"{stderr_key}_line_count", _output_line_count(stderr))
+
+
+def _terminate_sys_mount_process(mount_proc: subprocess.Popen[str], span: Any) -> None:
+    returncode_before_cleanup = mount_proc.poll()
+    span.set_data("returncode_before_cleanup", returncode_before_cleanup)
+
+    if returncode_before_cleanup is not None:
+        span.set_data("already_exited", True)
+        return
+
+    span.set_data("sent_signal", "SIGINT")
+    mount_proc.send_signal(signal.SIGINT)
+    try:
+        # Drain remaining output while waiting, so a full stdout pipe cannot block unmount teardown.
+        remaining_stdout, remaining_stderr = mount_proc.communicate(timeout=_SYS_MOUNT_CLEANUP_TIMEOUT_SECONDS)
+    except subprocess.TimeoutExpired as error:
+        span.set_status("internal_error")
+        span.set_data("sigint_timeout_seconds", _SYS_MOUNT_CLEANUP_TIMEOUT_SECONDS)
+        span.set_data("timed_out_after_sigint", True)
+        _record_mount_process_output(
+            span,
+            "partial_stdout_after_sigint",
+            "partial_stderr_after_sigint",
+            error.output,
+            error.stderr,
+        )
+        logger.warning("Mount process did not terminate after SIGINT, killing it")
+        mount_proc.kill()
+        span.set_data("killed", True)
+        remaining_stdout, remaining_stderr = mount_proc.communicate()
+        span.set_data("returncode_after_kill", mount_proc.returncode)
+        _record_mount_process_output(
+            span,
+            "remaining_stdout_after_kill",
+            "remaining_stderr_after_kill",
+            remaining_stdout,
+            remaining_stderr,
+        )
+        return
+
+    span.set_data("timed_out_after_sigint", False)
+    span.set_data("returncode_after_sigint", mount_proc.returncode)
+    _record_mount_process_output(
+        span,
+        "remaining_stdout_after_sigint",
+        "remaining_stderr_after_sigint",
+        remaining_stdout,
+        remaining_stderr,
+    )
+
+
+def _cleanup_sys_mount_directory(mount_point: Path, span: Any) -> None:
+    span.set_data("mount_point_exists_before_directory_cleanup", mount_point.exists())
+    if mount_point.exists():
+        logger.warning("Mount point still exists after unmount, attempting cleanup", extra={"mount_point": mount_point})
+        try:
+            shutil.rmtree(mount_point)
+        except Exception as e:
+            span.set_status("internal_error")
+            logger.error("Failed to clean up mount point", extra={"mount_point": mount_point, "exception": e})
+    span.set_data("mount_point_exists_after_directory_cleanup", mount_point.exists())
+
+
+def _cleanup_sys_image_mount(mount: SysImageMount) -> None:
+    with sentry_sdk.start_span(op="subprocess.ipsw_mount_cleanup", name="Unmount sys image") as span:
+        span.set_data("requested_mount_point", str(mount.requested_mount_point))
+        if mount.active_mount_point is not None:
+            span.set_data("active_mount_point", str(mount.active_mount_point))
+
+        _terminate_sys_mount_process(mount.process, span)
+        _cleanup_sys_mount_directory(mount.requested_mount_point, span)
+
+    for extracted_mount_artifact_path in mount.extracted_artifact_paths:
+        _cleanup_mount_artifact(extracted_mount_artifact_path)
+        if extracted_mount_artifact_path.suffix == ".aea":
+            _cleanup_mount_artifact(
+                extracted_mount_artifact_path.with_suffix(""),
+                description="decrypted DMG artifact left by ipsw mount",
+            )
 
 
 def _manifest_component_path(component: object) -> str | None:
@@ -386,6 +652,7 @@ class IpswExtractor:
                 )
 
             span.set_data("extract_dir", directory_data(extract_dir))
+            span.set_data("extract_output_tree", _directory_tree_stats(extract_dir).to_span_data())
             return extract_dir
 
     def run(self) -> Path:
@@ -453,7 +720,23 @@ class IpswExtractor:
         return self.processing_dir / "sys_mount"
 
     def _symsort_sys_image(self) -> None:
-        # mount the sys image (the process waits for sigint)
+        with self._mounted_sys_image() as active_mount_point:
+            self._symsort(active_mount_point, ignore_errors=True, record_input_tree=False)
+
+    @contextmanager
+    def _mounted_sys_image(self) -> Generator[Path, None, None]:
+        mount = self._prepare_sys_image_mount()
+        try:
+            if mount.error is not None:
+                raise IpswExtractError(mount.error)
+            if mount.active_mount_point is None:
+                raise IpswExtractError(f"Could not determine sys image mount point for {self.ipsw_path}")
+
+            yield mount.active_mount_point
+        finally:
+            _cleanup_sys_image_mount(mount)
+
+    def _prepare_sys_image_mount(self) -> SysImageMount:
         mount_point = self._sys_mount_point()
         if mount_point.exists():
             logger.warning("Removing stale sys image mount point before mount", extra={"mount_point": mount_point})
@@ -466,6 +749,7 @@ class IpswExtractor:
         extracted_mount_artifact_paths: list[Path] = []
         active_mount_point: Path | None = None
         mount_error: str | None = None
+
         with sentry_sdk.start_span(op="subprocess.ipsw_mount", name="Mount sys image") as mount_span:
             mount_span.set_data("requested_mount_point", str(mount_point))
             mount_command = [
@@ -489,7 +773,7 @@ class IpswExtractor:
                 text=True,
             )
 
-            # read mount-output until we get the mount-point
+            # Read only until ipsw reports the mount point. Cleanup drains the remaining output later.
             while mount_proc.stdout:
                 line = mount_proc.stdout.readline()
                 if not line:
@@ -503,19 +787,22 @@ class IpswExtractor:
                 ):
                     extracted_mount_artifact_paths.append(extracted_mount_artifact_path)
 
-                mount_point_match = mount_point_re.match(line)
+                mount_point_match = _MOUNT_POINT_RE.match(line)
                 if not mount_point_match:
                     continue
 
                 active_mount_point = Path(mount_point_match.group(1))
                 break
 
+            mount_span.set_data("mount_output_line_count", len(mount_output_lines))
+            if mount_output_lines:
+                mount_span.set_data("mount_output_preview", mount_output_lines[:20])
+
             if active_mount_point:
                 mount_span.set_data("mount_point", str(active_mount_point))
             else:
                 mount_output = "\n".join(mount_output_lines)
                 mount_summary = _summarize_ipsw_stderr(mount_output)
-                mount_span.set_data("mount_output_preview", mount_output_lines[:20])
                 mount_span.set_data("mount_output_summary", mount_summary)
                 mount_span.set_status("internal_error")
                 if mount_summary:
@@ -523,44 +810,13 @@ class IpswExtractor:
                 else:
                     mount_error = f"Could not determine sys image mount point for {self.ipsw_path}"
 
-        try:
-            if mount_error is not None:
-                raise IpswExtractError(mount_error)
-
-            if active_mount_point is None:
-                raise IpswExtractError(f"Could not determine sys image mount point for {self.ipsw_path}")
-
-            # symsort the entire sys mount-point
-            self._symsort(active_mount_point, ignore_errors=True)
-        finally:
-            # SIGINT the mount process and wait for it to unmount
-            if mount_proc.poll() is None:
-                mount_proc.send_signal(signal.SIGINT)
-                try:
-                    # Wait for process to cleanly unmount (timeout after 60 seconds)
-                    mount_proc.wait(timeout=60)
-                except subprocess.TimeoutExpired:
-                    logger.warning("Mount process did not terminate after SIGINT, killing it")
-                    mount_proc.kill()
-                    mount_proc.wait()
-
-            # Clean up mount point directory if it still exists (in case unmount failed)
-            if mount_point.exists():
-                logger.warning(
-                    "Mount point still exists after unmount, attempting cleanup", extra={"mount_point": mount_point}
-                )
-                try:
-                    shutil.rmtree(mount_point)
-                except Exception as e:
-                    logger.error("Failed to clean up mount point", extra={"mount_point": mount_point, "exception": e})
-
-            for extracted_mount_artifact_path in extracted_mount_artifact_paths:
-                _cleanup_mount_artifact(extracted_mount_artifact_path)
-                if extracted_mount_artifact_path.suffix == ".aea":
-                    _cleanup_mount_artifact(
-                        extracted_mount_artifact_path.with_suffix(""),
-                        description="decrypted DMG artifact left by ipsw mount",
-                    )
+        return SysImageMount(
+            process=mount_proc,
+            requested_mount_point=mount_point,
+            active_mount_point=active_mount_point,
+            extracted_artifact_paths=extracted_mount_artifact_paths,
+            error=mount_error,
+        )
 
     def _ipsw_split(self, extract_dir: Path, arch: Arch | None = None) -> Path:
         arch_label = str(arch) if arch is not None else "default"
@@ -587,6 +843,7 @@ class IpswExtractor:
             result = dyld_split(dsc_root_file, split_dir_arch)
             span.set_data("dyld_split", subprocess_result_data(result))
             span.set_data("split_dir", directory_data(split_dir_arch))
+            span.set_data("split_output_tree", _directory_tree_stats(split_dir_arch).to_span_data())
 
             if result.returncode != 0:
                 span.set_status("internal_error")
@@ -597,17 +854,28 @@ class IpswExtractor:
 
             return split_dir
 
-    def _symsort(self, split_dir: Path, ignore_errors: bool = False) -> None:
+    def _symsort(self, split_dir: Path, ignore_errors: bool = False, record_input_tree: bool = True) -> None:
         output_dir = self.symbols_dir()
         logger.info("Symsorting %s -> %s", split_dir, output_dir)
 
         with sentry_sdk.start_span(op="ipsw.symsort", name=f"Symsort IPSW {self.bundle_id}") as span:
             span.set_data("bundle_id", self.bundle_id)
             span.set_data("split_dir", directory_data(split_dir))
+            if record_input_tree:
+                span.set_data("input_tree", _directory_tree_stats(split_dir).to_span_data())
+
+            output_tree_before = _directory_tree_stats(output_dir)
             span.set_data("output_dir", directory_data(output_dir))
 
             result = symsort(output_dir, self.prefix, self.bundle_id, split_dir, ignore_errors)
             span.set_data("symsort", subprocess_result_data(result))
+            span.set_data("symsorter_summary", _parse_symsorter_summary(result.stdout, result.stderr))
+
+            output_tree_after = _directory_tree_stats(output_dir)
+            span.set_data(
+                "output_tree_delta", _directory_tree_delta(output_tree_before, output_tree_after).to_span_data()
+            )
+            span.set_data("output_tree_total_after", output_tree_after.to_span_data())
 
             if result.returncode != 0:
                 span.set_status("internal_error")
@@ -620,9 +888,6 @@ class IpswExtractError(Exception):
 
 class IpswExtractTimeoutError(IpswExtractError, TimeoutError):
     pass
-
-
-_RESERVED_PROCESSING_DIR_NAMES = frozenset({"split_out", "symbols", "sys_mount"})
 
 
 def find_extraction_dir(processing_dir: Path) -> Path | None:
@@ -643,21 +908,6 @@ def find_extraction_dir(processing_dir: Path) -> Path | None:
     return None
 
 
-_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*m")
-_LEADING_IPSW_GLYPH_RE = re.compile(r"^\s*[•⨯]\s*")
-_ERROR_SUMMARY_MARKERS = (
-    "error",
-    "failed",
-    "invalid",
-    "not found",
-    "unable",
-    "unknown flag",
-    "must specify",
-)
-_IGNORED_IPSW_HELP_PREFIXES = ("Usage:", "Aliases:", "Examples:", "Flags:", "Global Flags:")
-_FCS_KEY_URL_LABEL = "[com.apple.wkms.fcs-key-url]:"
-
-
 def _strip_ansi(text: str) -> str:
     return _ANSI_ESCAPE_RE.sub("", text)
 
@@ -668,7 +918,7 @@ def _normalize_ipsw_output_line(line: str) -> str:
 
 def _parse_extracted_mount_artifact_path(line: str) -> Path | None:
     normalized_line = _normalize_ipsw_output_line(_strip_ansi(line))
-    match = extracted_mount_artifact_re.match(normalized_line)
+    match = _EXTRACTED_MOUNT_ARTIFACT_RE.match(normalized_line)
     if not match:
         return None
     return Path(match.group(1))

--- a/tests/test_extract_utils.py
+++ b/tests/test_extract_utils.py
@@ -7,6 +7,7 @@ the OTA and IPSW extraction workflows.
 
 import json
 import plistlib
+import signal
 import subprocess
 import tempfile
 import zipfile
@@ -21,6 +22,9 @@ from symx.ipsw.extract import (
     IpswExtractError,
     IpswExtractTimeoutError,
     IpswExtractor,
+    _directory_tree_delta,
+    _directory_tree_stats,
+    _parse_symsorter_summary,
     find_extraction_dir,
     generate_bundle_id,
     inspect_ipsw_dmg_paths,
@@ -150,6 +154,44 @@ def _make_ipsw_extractor(tmp_path: Path) -> IpswExtractor:
     return IpswExtractor(IpswPlatform.IPADOS, "iPad15,7_26.4.2_23E261_Restore.ipsw", processing_dir, ipsw_path)
 
 
+def test_directory_tree_stats_counts_unique_files_without_following_links(tmp_path: Path) -> None:
+    file_path = tmp_path / "file"
+    file_path.write_bytes(b"abc")
+    nested = tmp_path / "nested"
+    nested.mkdir()
+    (nested / "other").write_bytes(b"data")
+    (tmp_path / "hardlink").hardlink_to(file_path)
+    (tmp_path / "symlink").symlink_to(file_path)
+
+    stats = _directory_tree_stats(tmp_path)
+
+    assert stats.file_count == 2
+    assert stats.total_file_size_bytes == 7
+    assert stats.directory_count == 1
+    assert stats.symlink_count == 1
+
+
+def test_directory_tree_delta_uses_zero_for_missing_before_counts(tmp_path: Path) -> None:
+    before = _directory_tree_stats(tmp_path / "missing")
+    (tmp_path / "created").write_bytes(b"abc")
+    after = _directory_tree_stats(tmp_path)
+
+    delta = _directory_tree_delta(before, after)
+    assert delta.file_count_delta == 1
+    assert delta.total_file_size_bytes_delta == 3
+
+
+def test_parse_symsorter_summary_extracts_counts() -> None:
+    assert _parse_symsorter_summary(
+        b"Done.\nSorted 42 debug files\nCreated 2 source bundles\n",
+        b"WARNING: File foo already exists, you seem to have duplicate debug files\n",
+    ) == {
+        "sorted_debug_files": 42,
+        "created_source_bundles": 2,
+        "duplicate_debug_file_warnings": 1,
+    }
+
+
 def test_ipsw_extract_dsc_timeout_preserves_timeout_contract_and_diagnostics(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -272,6 +314,7 @@ def test_ipsw_symsort_sys_image_passes_vendored_pem_db_when_available(
     mount_point = extractor._sys_mount_point()
     mount_point.mkdir()
     commands: list[list[str]] = []
+    communicate_timeouts: list[int | None] = []
     symsort_calls: list[tuple[Path, bool]] = []
 
     class FakeStdout:
@@ -300,8 +343,13 @@ def test_ipsw_symsort_sys_image_passes_vendored_pem_db_when_available(
         def send_signal(self, sig: int) -> None:
             return None
 
+        def communicate(self, timeout: int | None = None) -> tuple[str, str]:
+            communicate_timeouts.append(timeout)
+            self.returncode = 0
+            return "", ""
+
         def wait(self, timeout: int | None = None) -> int:
-            return 0
+            raise AssertionError("mount cleanup should drain with communicate(), not wait()")
 
         def kill(self) -> None:
             return None
@@ -311,7 +359,9 @@ def test_ipsw_symsort_sys_image_passes_vendored_pem_db_when_available(
     monkeypatch.setattr(
         IpswExtractor,
         "_symsort",
-        lambda self, split_dir, ignore_errors=False: symsort_calls.append((split_dir, ignore_errors)),
+        lambda self, split_dir, ignore_errors=False, record_input_tree=True: symsort_calls.append(
+            (split_dir, ignore_errors)
+        ),
     )
 
     extractor._symsort_sys_image()
@@ -329,7 +379,71 @@ def test_ipsw_symsort_sys_image_passes_vendored_pem_db_when_available(
             str(pem_db),
         ]
     ]
+    assert communicate_timeouts == [60]
     assert symsort_calls == [(mount_point, True)]
+
+
+def test_ipsw_symsort_sys_image_kills_mount_process_after_cleanup_timeout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    extractor = _make_ipsw_extractor(tmp_path)
+    mount_point = extractor._sys_mount_point()
+    mount_point.mkdir()
+    communicate_timeouts: list[int | None] = []
+    sent_signals: list[int] = []
+    killed = False
+
+    class FakeStdout:
+        def __init__(self, lines: list[str]) -> None:
+            self._lines = iter(lines)
+
+        def readline(self) -> str:
+            return next(self._lines, "")
+
+    class FakePopen:
+        def __init__(
+            self,
+            command: list[str],
+            stdout: object = None,
+            stderr: object = None,
+            bufsize: int | None = None,
+            text: bool | None = None,
+        ) -> None:
+            self.command = command
+            self.stdout = FakeStdout([f"Press Ctrl+C to unmount '{mount_point}'\n", ""])
+            self.returncode: int | None = None
+
+        def poll(self) -> int | None:
+            return self.returncode
+
+        def send_signal(self, sig: int) -> None:
+            sent_signals.append(sig)
+
+        def communicate(self, timeout: int | None = None) -> tuple[str, str]:
+            communicate_timeouts.append(timeout)
+            if timeout is not None:
+                raise subprocess.TimeoutExpired(self.command, timeout, output="partial unmount output")
+            self.returncode = -9
+            return "post-kill unmount output", ""
+
+        def wait(self, timeout: int | None = None) -> int:
+            raise AssertionError("mount cleanup should drain with communicate(), not wait()")
+
+        def kill(self) -> None:
+            nonlocal killed
+            killed = True
+            self.returncode = -9
+
+    monkeypatch.setattr("symx.ipsw.extract.subprocess.Popen", FakePopen)
+    monkeypatch.setattr(
+        IpswExtractor, "_symsort", lambda self, split_dir, ignore_errors=False, record_input_tree=True: None
+    )
+
+    extractor._symsort_sys_image()
+
+    assert sent_signals == [signal.SIGINT]
+    assert communicate_timeouts == [60, None]
+    assert killed
 
 
 def test_ipsw_symsort_sys_image_cleans_extracted_aea_on_failure(
@@ -373,13 +487,19 @@ def test_ipsw_symsort_sys_image_cleans_extracted_aea_on_failure(
         def send_signal(self, sig: int) -> None:
             return None
 
+        def communicate(self, timeout: int | None = None) -> tuple[str, str]:
+            self.returncode = 0
+            return "", ""
+
         def wait(self, timeout: int | None = None) -> int:
-            return 0
+            raise AssertionError("mount cleanup should drain with communicate(), not wait()")
 
         def kill(self) -> None:
             return None
 
-    def fake_symsort(self: IpswExtractor, split_dir: Path, ignore_errors: bool = False) -> None:
+    def fake_symsort(
+        self: IpswExtractor, split_dir: Path, ignore_errors: bool = False, record_input_tree: bool = True
+    ) -> None:
         raise IpswExtractError("boom")
 
     monkeypatch.setattr("symx.ipsw.extract.subprocess.Popen", FakePopen)
@@ -439,7 +559,7 @@ def test_ipsw_symsort_sys_image_raises_on_mount_failure_and_cleans_mount_artifac
             return None
 
         def wait(self, timeout: int | None = None) -> int:
-            return self.returncode
+            raise AssertionError("mount cleanup should drain with communicate(), not wait()")
 
         def kill(self) -> None:
             return None


### PR DESCRIPTION
Also adds lightweight IPSW extraction diagnostics to explain runner-specific slowdowns.

The traces showed large differences on Bitrise vs Cirrus for work that touches the IPSW/image/mount stack, while downstream DSC split/symsort work was much closer. This PR adds file/byte counts at stage boundaries, so spans show not only the duration but also how much data each stage produced for the next one.