### PR TITLE
 ref: move ipsw extraction config into a request

### DIFF
--- a/symx/ipsw/app/__init__.py
+++ b/symx/ipsw/app/__init__.py
@@ -8,7 +8,7 @@ import typer
 from symx.gcs import parse_gcs_url
 from symx.tools import validate_shell_deps
 from symx.ipsw.model import IpswPlatform
-from symx.ipsw.extract import IpswExtractor
+from symx.ipsw.extract import IpswExtractionRequest, extract_ipsw
 from symx.ipsw.runners import (
     import_meta_from_appledb,
     mirror as mirror_runner,
@@ -99,8 +99,8 @@ def extract_file(
 
         output_dir.mkdir(parents=True, exist_ok=True)
 
-        extractor = IpswExtractor(platform, ipsw_file.name, output_dir, ipsw_file)
-        symbols_dir = extractor.run()
+        request = IpswExtractionRequest.from_local_ipsw(platform, ipsw_file, output_dir)
+        symbols_dir = extract_ipsw(request)
 
         typer.echo(f"Extracted symbols to: {symbols_dir}")
 

--- a/symx/ipsw/extract.py
+++ b/symx/ipsw/extract.py
@@ -562,6 +562,9 @@ class _IpswExtractionRun:
         self.bundle_id = generate_bundle_id(request.ipsw_path.name)
         self.prefix = map_platform_to_prefix(request.platform)
         self.platform = request.platform
+        self.macos_dsc_architectures = (
+            _macos_dsc_architectures(request.version) if request.platform == IpswPlatform.MACOS else ()
+        )
         if not request.processing_dir.is_dir():
             raise ValueError(f"IPSW processing path is expected to be a directory: {request.processing_dir}")
         self.processing_dir = request.processing_dir
@@ -743,7 +746,7 @@ class _IpswExtractionRun:
         if self.platform == IpswPlatform.MACOS:
             compressed_archives: list[tuple[Path, Arch]] = []
 
-            for arch in _macos_dsc_architectures(self.request.version):
+            for arch in self.macos_dsc_architectures:
                 logger.info("Extracting and processing DSC for %s", arch)
                 with sentry_sdk.start_span(op="ipsw.extract.dsc_arch", name=f"Extract+split DSC {arch}") as arch_span:
                     arch_span.set_data("arch", str(arch))
@@ -1063,7 +1066,13 @@ def _version_major(version: str | None) -> int | None:
 
 def _macos_dsc_architectures(version: str | None) -> list[Arch]:
     major_version = _version_major(version)
-    if major_version is not None and major_version >= _MACOS_ARM64E_ONLY_DSC_MIN_MAJOR_VERSION:
+    if major_version is None:
+        version_label = "<missing>" if version is None else repr(version)
+        raise IpswExtractError(
+            f"Cannot determine required macOS DSC architectures: missing or unparseable macOS version {version_label}"
+        )
+
+    if major_version >= _MACOS_ARM64E_ONLY_DSC_MIN_MAJOR_VERSION:
         return [Arch.ARM64E]
     return [Arch.ARM64E, Arch.X86_64]
 

--- a/symx/ipsw/extract.py
+++ b/symx/ipsw/extract.py
@@ -8,15 +8,16 @@ import stat
 import subprocess
 import tempfile
 import zipfile
-from collections.abc import Generator
+from collections.abc import Generator, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, TypeGuard
 from urllib.parse import urlparse
 
 import sentry_sdk
+from pydantic import BaseModel, ConfigDict, Field
 
 from symx.diagnostics import (
     decode_subprocess_output,
@@ -52,7 +53,7 @@ _ERROR_SUMMARY_MARKERS = (
 _IGNORED_IPSW_HELP_PREFIXES = ("Usage:", "Aliases:", "Examples:", "Flags:", "Global Flags:")
 _FCS_KEY_URL_LABEL = "[com.apple.wkms.fcs-key-url]:"
 _VENDORED_PEM_DB = Path(__file__).resolve().parent / "data" / "fcs-keys.json"
-_MACOS_VERSION_RE = re.compile(r"^UniversalMac_(\d+)(?:[._]|$)")
+_VERSION_MAJOR_RE = re.compile(r"^(\d+)")
 _MACOS_ARM64E_ONLY_DSC_MIN_MAJOR_VERSION = 27
 
 
@@ -116,6 +117,92 @@ class SysImageMount:
     active_mount_point: Path | None
     extracted_artifact_paths: list[Path]
     error: str | None = None
+
+
+@dataclass(frozen=True)
+class IpswProductMetadata:
+    version: str | None = None
+    build: str | None = None
+    devices: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class IpswDmgPaths:
+    system: str | None
+    filesystem: str | None
+    selected: str | None
+
+    def to_span_data(self) -> dict[str, str | None]:
+        return {
+            "system": self.system,
+            "filesystem": self.filesystem,
+            "selected": self.selected,
+        }
+
+
+class _IpswBuildManifestModel(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+
+class IpswManifestComponentInfo(_IpswBuildManifestModel):
+    path: str | None = Field(None, alias="Path")
+
+
+class IpswManifestComponent(_IpswBuildManifestModel):
+    info: IpswManifestComponentInfo | None = Field(None, alias="Info")
+
+
+class IpswBuildIdentityManifest(_IpswBuildManifestModel):
+    cryptex_system_os: IpswManifestComponent | None = Field(None, alias="Cryptex1,SystemOS")
+    os: IpswManifestComponent | None = Field(None, alias="OS")
+
+
+class IpswBuildIdentityInfo(_IpswBuildManifestModel):
+    variant: str | None = Field(None, alias="Variant")
+
+
+class IpswBuildIdentity(_IpswBuildManifestModel):
+    manifest: IpswBuildIdentityManifest | None = Field(None, alias="Manifest")
+    info: IpswBuildIdentityInfo | None = Field(None, alias="Info")
+
+
+class IpswBuildManifest(_IpswBuildManifestModel):
+    product_version: str | None = Field(None, alias="ProductVersion")
+    product_build_version: str | None = Field(None, alias="ProductBuildVersion")
+    supported_product_types: tuple[str, ...] = Field(default_factory=tuple, alias="SupportedProductTypes")
+    build_identities: tuple[IpswBuildIdentity, ...] | None = Field(None, alias="BuildIdentities")
+
+
+@dataclass(frozen=True)
+class IpswExtractionRequest:
+    platform: IpswPlatform
+    ipsw_path: Path
+    processing_dir: Path
+    version: str | None = None
+    build: str | None = None
+    devices: tuple[str, ...] = ()
+
+    @classmethod
+    def from_local_ipsw(
+        cls,
+        platform: IpswPlatform,
+        ipsw_path: Path,
+        processing_dir: Path,
+    ) -> "IpswExtractionRequest":
+        try:
+            metadata = inspect_ipsw_product_metadata(ipsw_path)
+        except Exception as error:
+            logger.warning("Failed to inspect IPSW product metadata for %s: %s", ipsw_path.name, error)
+            metadata = IpswProductMetadata()
+
+        return cls(
+            platform=platform,
+            ipsw_path=ipsw_path,
+            processing_dir=processing_dir,
+            version=metadata.version,
+            build=metadata.build,
+            devices=metadata.devices,
+        )
 
 
 def vendored_ipsw_pem_db_path() -> Path | None:
@@ -324,62 +411,53 @@ def _cleanup_sys_image_mount(mount: SysImageMount) -> None:
             )
 
 
-def _manifest_component_path(component: object) -> str | None:
-    if not isinstance(component, dict):
+def _is_object_mapping(value: object) -> TypeGuard[Mapping[object, object]]:
+    return isinstance(value, dict)
+
+
+def _manifest_component_path(component: IpswManifestComponent | None) -> str | None:
+    if component is None or component.info is None:
         return None
-
-    component_dict = cast(dict[str, Any], component)
-    info = component_dict.get("Info")
-    if not isinstance(info, dict):
-        return None
-
-    info_dict = cast(dict[str, Any], info)
-    path = info_dict.get("Path")
-    if isinstance(path, str) and path:
-        return path
-    return None
+    return component.info.path or None
 
 
-def inspect_ipsw_dmg_paths(ipsw_path: Path) -> dict[str, str | None]:
+def _read_ipsw_build_manifest(ipsw_path: Path) -> IpswBuildManifest:
     with zipfile.ZipFile(ipsw_path) as archive:
-        build_manifest_obj = plistlib.loads(archive.read("BuildManifest.plist"))
+        build_manifest_obj: object = plistlib.loads(archive.read("BuildManifest.plist"))
 
-    if not isinstance(build_manifest_obj, dict):
-        raise ValueError(f"Unexpected BuildManifest.plist structure in {ipsw_path}")
+    return IpswBuildManifest.model_validate(build_manifest_obj)
 
-    build_manifest = cast(dict[str, Any], build_manifest_obj)
-    build_identities_obj = build_manifest.get("BuildIdentities")
-    if not isinstance(build_identities_obj, list):
+
+def inspect_ipsw_product_metadata(ipsw_path: Path) -> IpswProductMetadata:
+    build_manifest = _read_ipsw_build_manifest(ipsw_path)
+    return IpswProductMetadata(
+        version=build_manifest.product_version,
+        build=build_manifest.product_build_version,
+        devices=build_manifest.supported_product_types,
+    )
+
+
+def inspect_ipsw_dmg_paths(ipsw_path: Path) -> IpswDmgPaths:
+    build_manifest = _read_ipsw_build_manifest(ipsw_path)
+    if build_manifest.build_identities is None:
         raise ValueError(f"BuildManifest.plist has no BuildIdentities list in {ipsw_path}")
 
-    build_identities = cast(list[object], build_identities_obj)
     system_dmg: str | None = None
     filesystem_dmgs: list[str] = []
 
-    for build_identity_obj in build_identities:
-        if not isinstance(build_identity_obj, dict):
+    for build_identity in build_manifest.build_identities:
+        manifest = build_identity.manifest
+        if manifest is None:
             continue
 
-        build_identity = cast(dict[str, Any], build_identity_obj)
-        manifest_obj = build_identity.get("Manifest")
-        if not isinstance(manifest_obj, dict):
-            continue
-
-        manifest = cast(dict[str, Any], manifest_obj)
         if system_dmg is None:
-            system_dmg = _manifest_component_path(manifest.get("Cryptex1,SystemOS"))
+            system_dmg = _manifest_component_path(manifest.cryptex_system_os)
 
-        filesystem_dmg = _manifest_component_path(manifest.get("OS"))
+        filesystem_dmg = _manifest_component_path(manifest.os)
         if filesystem_dmg is None:
             continue
 
-        info_obj = build_identity.get("Info")
-        variant = None
-        if isinstance(info_obj, dict):
-            info = cast(dict[str, Any], info_obj)
-            variant_obj = info.get("Variant")
-            if isinstance(variant_obj, str):
-                variant = variant_obj
+        variant = build_identity.info.variant if build_identity.info is not None else None
         if variant is not None and "Recovery" in variant:
             continue
 
@@ -389,11 +467,7 @@ def inspect_ipsw_dmg_paths(ipsw_path: Path) -> dict[str, str | None]:
     filesystem_dmg = filesystem_dmgs[0] if len(filesystem_dmgs) == 1 else None
     selected_dmg = system_dmg if system_dmg is not None else filesystem_dmg
 
-    return {
-        "system": system_dmg,
-        "filesystem": filesystem_dmg,
-        "selected": selected_dmg,
-    }
+    return IpswDmgPaths(system=system_dmg, filesystem=filesystem_dmg, selected=selected_dmg)
 
 
 def _extract_ipsw_member(ipsw_path: Path, member_name: str, output_path: Path) -> Path:
@@ -478,29 +552,25 @@ def _decompress_archive(archive_path: Path, target_dir: Path) -> None:
         raise IpswExtractError(f"zstd decompression failed with return code {zstd_proc.returncode}")
 
 
-# TODO: there is good chance that we should split the extractor into separate classes based on at least platform
-#   and provide a factory function that instantiates the right extractor class using artifact and maybe source.
-class IpswExtractor:
-    def __init__(
-        self,
-        platform: IpswPlatform,
-        file_name: str,
-        processing_dir: Path,
-        ipsw_path: Path,
-    ):
-        self.file_name = file_name
-        self.bundle_id = generate_bundle_id(file_name)
-        self.prefix = map_platform_to_prefix(platform)
-        self.platform = platform
-        if not processing_dir.is_dir():
-            raise ValueError(f"IPSW path is expected to be a directory: {processing_dir}")
-        self.processing_dir = processing_dir
+def extract_ipsw(request: IpswExtractionRequest) -> Path:
+    return _IpswExtractionRun(request).run()
+
+
+class _IpswExtractionRun:
+    def __init__(self, request: IpswExtractionRequest):
+        self.request = request
+        self.bundle_id = generate_bundle_id(request.ipsw_path.name)
+        self.prefix = map_platform_to_prefix(request.platform)
+        self.platform = request.platform
+        if not request.processing_dir.is_dir():
+            raise ValueError(f"IPSW processing path is expected to be a directory: {request.processing_dir}")
+        self.processing_dir = request.processing_dir
         _log_directory_contents(self.processing_dir)
 
-        if not ipsw_path.is_file():
-            raise ValueError(f"IPSW path is expected to be a file: {ipsw_path}")
+        if not request.ipsw_path.is_file():
+            raise ValueError(f"IPSW path is expected to be a file: {request.ipsw_path}")
 
-        self.ipsw_path = ipsw_path
+        self.ipsw_path = request.ipsw_path
         self._aea_preflight_complete = False
 
     def _ipsw_aea_preflight(self) -> None:
@@ -518,16 +588,16 @@ class IpswExtractor:
                 self._aea_preflight_complete = True
                 return
 
-            span.set_data("ipsw_dmg_paths", dmg_paths)
-            selected_dmg = dmg_paths.get("selected")
-            if not isinstance(selected_dmg, str) or not selected_dmg.endswith(".aea"):
+            span.set_data("ipsw_dmg_paths", dmg_paths.to_span_data())
+            selected_dmg = dmg_paths.selected
+            if selected_dmg is None or not selected_dmg.endswith(".aea"):
                 self._aea_preflight_complete = True
                 return
 
             probe_data: dict[str, object] = {
                 "selected_dmg": selected_dmg,
-                "system_dmg": dmg_paths.get("system"),
-                "filesystem_dmg": dmg_paths.get("filesystem"),
+                "system_dmg": dmg_paths.system,
+                "filesystem_dmg": dmg_paths.filesystem,
             }
             pem_db_path = vendored_ipsw_pem_db_path()
             if pem_db_path is not None:
@@ -585,8 +655,8 @@ class IpswExtractor:
                     summary = _summarize_ipsw_stderr(key_result.stderr) or "ipsw fw aea --key failed"
                     raise IpswExtractError(
                         f"IPSW AEA preflight failed for {self.ipsw_path}: "
-                        f"selected_dmg={selected_dmg}; system_dmg={dmg_paths.get('system')}; "
-                        f"filesystem_dmg={dmg_paths.get('filesystem')}; fcs_key={fcs_key_id or '<unknown>'}; "
+                        f"selected_dmg={selected_dmg}; system_dmg={dmg_paths.system}; "
+                        f"filesystem_dmg={dmg_paths.filesystem}; fcs_key={fcs_key_id or '<unknown>'}; "
                         f"vendored_db_hit={vendored_db_hit}; {summary}"
                     )
 
@@ -673,10 +743,12 @@ class IpswExtractor:
         if self.platform == IpswPlatform.MACOS:
             compressed_archives: list[tuple[Path, Arch]] = []
 
-            for arch in _macos_dsc_architectures(self.file_name):
+            for arch in _macos_dsc_architectures(self.request.version):
                 logger.info("Extracting and processing DSC for %s", arch)
                 with sentry_sdk.start_span(op="ipsw.extract.dsc_arch", name=f"Extract+split DSC {arch}") as arch_span:
                     arch_span.set_data("arch", str(arch))
+                    arch_span.set_data("version", self.request.version)
+                    arch_span.set_data("build", self.request.build)
 
                     extract_dir = self._ipsw_extract_dsc(arch)
                     _log_directory_contents(extract_dir)
@@ -691,7 +763,7 @@ class IpswExtractor:
                         compressed_archives.append((archive_path, arch))
                         logger.info("Finished compressing %s split to %s", arch, archive_path)
 
-            # Delete IPSW file now that both architectures are extracted and compressed
+            # Delete IPSW file now that all required DSC architectures are extracted and compressed
             if self.ipsw_path.exists():
                 logger.info("Deleting IPSW file to save space: %s", self.ipsw_path)
                 self.ipsw_path.unlink()
@@ -951,13 +1023,12 @@ def _vendored_ipsw_pem_db_keys() -> frozenset[str]:
         return frozenset()
 
     with pem_db_path.open() as handle:
-        raw_data_obj = json.load(handle)
+        raw_data_obj: object = json.load(handle)
 
-    if not isinstance(raw_data_obj, dict):
+    if not _is_object_mapping(raw_data_obj):
         raise ValueError(f"Vendored IPSW PEM DB must be a JSON object: {pem_db_path}")
 
-    raw_data = cast(dict[object, object], raw_data_obj)
-    return frozenset(str(key) for key in raw_data)
+    return frozenset(str(key) for key in raw_data_obj)
 
 
 def _summarize_ipsw_stderr(stderr: str | bytes | None) -> str | None:
@@ -980,9 +1051,19 @@ def _summarize_ipsw_stderr(stderr: str | bytes | None) -> str | None:
     return None
 
 
-def _macos_dsc_architectures(file_name: str) -> list[Arch]:
-    version_match = _MACOS_VERSION_RE.match(file_name)
-    if version_match is not None and int(version_match.group(1)) >= _MACOS_ARM64E_ONLY_DSC_MIN_MAJOR_VERSION:
+def _version_major(version: str | None) -> int | None:
+    if version is None:
+        return None
+
+    version_match = _VERSION_MAJOR_RE.match(version)
+    if version_match is None:
+        return None
+    return int(version_match.group(1))
+
+
+def _macos_dsc_architectures(version: str | None) -> list[Arch]:
+    major_version = _version_major(version)
+    if major_version is not None and major_version >= _MACOS_ARM64E_ONLY_DSC_MIN_MAJOR_VERSION:
         return [Arch.ARM64E]
     return [Arch.ARM64E, Arch.X86_64]
 

--- a/symx/ipsw/runners.py
+++ b/symx/ipsw/runners.py
@@ -15,8 +15,8 @@ from symx.model import (
 from symx.download import DownloadError, try_download_url_to_file
 from symx.fs import log_disk_usage
 from symx.tools import validate_shell_deps
-from symx.ipsw.model import IpswArtifact, IpswPlatform, IpswSource
-from symx.ipsw.extract import IpswExtractor
+from symx.ipsw.model import IpswArtifact, IpswSource
+from symx.ipsw.extract import IpswExtractionRequest, extract_ipsw, generate_bundle_id, map_platform_to_prefix
 from symx.ipsw.meta_sync.appledb import AppleDbIpswImport
 from symx.ipsw.mirror import verify_download
 from symx.ipsw.storage import IpswStorage
@@ -46,9 +46,7 @@ class ExtractionResult:
 class SymbolExtractor(Protocol):
     def validate_deps(self) -> None: ...
 
-    def extract(
-        self, platform: IpswPlatform, file_name: str, processing_dir: Path, ipsw_path: Path
-    ) -> ExtractionResult:
+    def extract(self, request: IpswExtractionRequest) -> ExtractionResult:
         """Run the full extract pipeline, return symbols dir + metadata."""
         ...
 
@@ -247,9 +245,15 @@ def extract(
                         with sentry_sdk.start_span(
                             op="ipsw.extract.run", name=f"IPSW extract+symsort {source.file_name}"
                         ):
-                            result = extractor.extract(
-                                artifact.platform, source.file_name, ipsw_storage.local_dir, local_path
+                            request = IpswExtractionRequest(
+                                platform=artifact.platform,
+                                ipsw_path=local_path,
+                                processing_dir=ipsw_storage.local_dir,
+                                version=artifact.version,
+                                build=artifact.build,
+                                devices=tuple(source.devices),
                             )
+                            result = extractor.extract(request)
 
                         with sentry_sdk.start_span(
                             op="gcs.upload_symbols", name=f"Upload symbols for {source.file_name}"
@@ -351,9 +355,10 @@ class _RealSymbolExtractor(SymbolExtractor):
     def validate_deps(self) -> None:
         validate_shell_deps()
 
-    def extract(
-        self, platform: IpswPlatform, file_name: str, processing_dir: Path, ipsw_path: Path
-    ) -> ExtractionResult:
-        extractor = IpswExtractor(platform, file_name, processing_dir, ipsw_path)
-        symbols_dir = extractor.run()
-        return ExtractionResult(symbols_dir=symbols_dir, prefix=extractor.prefix, bundle_id=extractor.bundle_id)
+    def extract(self, request: IpswExtractionRequest) -> ExtractionResult:
+        symbols_dir = extract_ipsw(request)
+        return ExtractionResult(
+            symbols_dir=symbols_dir,
+            prefix=map_platform_to_prefix(request.platform),
+            bundle_id=generate_bundle_id(request.ipsw_path.name),
+        )

--- a/tests/test_extract_utils.py
+++ b/tests/test_extract_utils.py
@@ -88,11 +88,25 @@ def test_macos_dsc_architectures_keep_x86_64_before_macos_27_metadata() -> None:
     ]
 
 
-def test_macos_dsc_architectures_default_to_legacy_arches_for_unknown_version() -> None:
-    assert ipsw_extract._macos_dsc_architectures(None) == [
-        Arch.ARM64E,
-        Arch.X86_64,
-    ]
+def test_macos_dsc_architectures_raise_for_missing_version() -> None:
+    with pytest.raises(IpswExtractError, match="missing or unparseable macOS version <missing>"):
+        ipsw_extract._macos_dsc_architectures(None)
+
+
+def test_macos_dsc_architectures_raise_for_unparseable_version() -> None:
+    with pytest.raises(IpswExtractError, match="missing or unparseable macOS version 'Sequoia'"):
+        ipsw_extract._macos_dsc_architectures("Sequoia")
+
+
+def test_macos_extraction_requires_version_before_running_side_effects(tmp_path: Path) -> None:
+    processing_dir = tmp_path / "processing"
+    processing_dir.mkdir()
+    ipsw_path = tmp_path / "UniversalMac_27.0_26A5353q_Restore.ipsw"
+    ipsw_path.touch()
+    request = IpswExtractionRequest(IpswPlatform.MACOS, ipsw_path, processing_dir)
+
+    with pytest.raises(IpswExtractError, match="missing or unparseable macOS version <missing>"):
+        _IpswExtractionRun(request)
 
 
 # --- find_extraction_dir tests ---

--- a/tests/test_extract_utils.py
+++ b/tests/test_extract_utils.py
@@ -20,15 +20,17 @@ from symx.model import Arch
 from symx.ipsw import extract as ipsw_extract
 from symx.ipsw.model import IpswPlatform
 from symx.ipsw.extract import (
+    IpswExtractionRequest,
     IpswExtractError,
     IpswExtractTimeoutError,
-    IpswExtractor,
+    _IpswExtractionRun,
     _directory_tree_delta,
     _directory_tree_stats,
     _parse_symsorter_summary,
     find_extraction_dir,
     generate_bundle_id,
     inspect_ipsw_dmg_paths,
+    inspect_ipsw_product_metadata,
     map_platform_to_prefix,
 )
 from subprocess import CompletedProcess
@@ -75,19 +77,19 @@ def test_generate_bundle_id_no_commas() -> None:
 # --- macOS DSC architecture policy tests ---
 
 
-def test_macos_dsc_architectures_omit_x86_64_for_macos_27_ipsw() -> None:
-    assert ipsw_extract._macos_dsc_architectures("UniversalMac_27.0_26A5353q_Restore.ipsw") == [Arch.ARM64E]
+def test_macos_dsc_architectures_omit_x86_64_for_macos_27_metadata() -> None:
+    assert ipsw_extract._macos_dsc_architectures("27.0") == [Arch.ARM64E]
 
 
-def test_macos_dsc_architectures_keep_x86_64_before_macos_27() -> None:
-    assert ipsw_extract._macos_dsc_architectures("UniversalMac_26.5.1_25F79_Restore.ipsw") == [
+def test_macos_dsc_architectures_keep_x86_64_before_macos_27_metadata() -> None:
+    assert ipsw_extract._macos_dsc_architectures("26.5.1") == [
         Arch.ARM64E,
         Arch.X86_64,
     ]
 
 
-def test_macos_dsc_architectures_default_to_legacy_arches_for_unrecognized_file_names() -> None:
-    assert ipsw_extract._macos_dsc_architectures("iPhone16,2_27.0_26A5353q_Restore.ipsw") == [
+def test_macos_dsc_architectures_default_to_legacy_arches_for_unknown_version() -> None:
+    assert ipsw_extract._macos_dsc_architectures(None) == [
         Arch.ARM64E,
         Arch.X86_64,
     ]
@@ -138,6 +140,38 @@ def test_find_extraction_dir_returns_first_match() -> None:
 # --- IPSW diagnostics tests ---
 
 
+def test_inspect_ipsw_product_metadata_reads_build_manifest(tmp_path: Path) -> None:
+    ipsw_path = tmp_path / "test.ipsw"
+    build_manifest = {
+        "ProductVersion": "27.0",
+        "ProductBuildVersion": "26A5353q",
+        "SupportedProductTypes": ["Mac17,1", "Mac17,2"],
+        "BuildIdentities": [],
+    }
+
+    with zipfile.ZipFile(ipsw_path, "w") as archive:
+        archive.writestr("BuildManifest.plist", plistlib.dumps(build_manifest))
+
+    expected_metadata = ipsw_extract.IpswProductMetadata(
+        version="27.0",
+        build="26A5353q",
+        devices=("Mac17,1", "Mac17,2"),
+    )
+    assert inspect_ipsw_product_metadata(ipsw_path) == expected_metadata
+    processing_dir = tmp_path / "processing"
+    processing_dir.mkdir()
+    assert IpswExtractionRequest.from_local_ipsw(
+        IpswPlatform.MACOS, ipsw_path, processing_dir
+    ) == IpswExtractionRequest(
+        platform=IpswPlatform.MACOS,
+        ipsw_path=ipsw_path,
+        processing_dir=processing_dir,
+        version=expected_metadata.version,
+        build=expected_metadata.build,
+        devices=expected_metadata.devices,
+    )
+
+
 def test_inspect_ipsw_dmg_paths_prefers_systemos_and_skips_recovery_filesystem(tmp_path: Path) -> None:
     ipsw_path = tmp_path / "test.ipsw"
     build_manifest = {
@@ -161,19 +195,20 @@ def test_inspect_ipsw_dmg_paths_prefers_systemos_and_skips_recovery_filesystem(t
     with zipfile.ZipFile(ipsw_path, "w") as archive:
         archive.writestr("BuildManifest.plist", plistlib.dumps(build_manifest))
 
-    assert inspect_ipsw_dmg_paths(ipsw_path) == {
-        "system": "system.dmg.aea",
-        "filesystem": "filesystem.dmg.aea",
-        "selected": "system.dmg.aea",
-    }
+    assert inspect_ipsw_dmg_paths(ipsw_path) == ipsw_extract.IpswDmgPaths(
+        system="system.dmg.aea",
+        filesystem="filesystem.dmg.aea",
+        selected="system.dmg.aea",
+    )
 
 
-def _make_ipsw_extractor(tmp_path: Path) -> IpswExtractor:
+def _make_ipsw_extractor(tmp_path: Path) -> _IpswExtractionRun:
     processing_dir = tmp_path / "processing"
     processing_dir.mkdir()
-    ipsw_path = tmp_path / "test.ipsw"
+    ipsw_path = tmp_path / "iPad15,7_26.4.2_23E261_Restore.ipsw"
     ipsw_path.touch()
-    return IpswExtractor(IpswPlatform.IPADOS, "iPad15,7_26.4.2_23E261_Restore.ipsw", processing_dir, ipsw_path)
+    request = IpswExtractionRequest(IpswPlatform.IPADOS, ipsw_path, processing_dir)
+    return _IpswExtractionRun(request)
 
 
 def test_directory_tree_stats_counts_unique_files_without_following_links(tmp_path: Path) -> None:
@@ -379,7 +414,7 @@ def test_ipsw_symsort_sys_image_passes_vendored_pem_db_when_available(
     monkeypatch.setattr("symx.ipsw.extract.vendored_ipsw_pem_db_path", lambda: pem_db)
     monkeypatch.setattr("symx.ipsw.extract.subprocess.Popen", FakePopen)
     monkeypatch.setattr(
-        IpswExtractor,
+        _IpswExtractionRun,
         "_symsort",
         lambda self, split_dir, ignore_errors=False, record_input_tree=True: symsort_calls.append(
             (split_dir, ignore_errors)
@@ -458,7 +493,7 @@ def test_ipsw_symsort_sys_image_kills_mount_process_after_cleanup_timeout(
 
     monkeypatch.setattr("symx.ipsw.extract.subprocess.Popen", FakePopen)
     monkeypatch.setattr(
-        IpswExtractor, "_symsort", lambda self, split_dir, ignore_errors=False, record_input_tree=True: None
+        _IpswExtractionRun, "_symsort", lambda self, split_dir, ignore_errors=False, record_input_tree=True: None
     )
 
     extractor._symsort_sys_image()
@@ -520,12 +555,12 @@ def test_ipsw_symsort_sys_image_cleans_extracted_aea_on_failure(
             return None
 
     def fake_symsort(
-        self: IpswExtractor, split_dir: Path, ignore_errors: bool = False, record_input_tree: bool = True
+        self: _IpswExtractionRun, split_dir: Path, ignore_errors: bool = False, record_input_tree: bool = True
     ) -> None:
         raise IpswExtractError("boom")
 
     monkeypatch.setattr("symx.ipsw.extract.subprocess.Popen", FakePopen)
-    monkeypatch.setattr(IpswExtractor, "_symsort", fake_symsort)
+    monkeypatch.setattr(_IpswExtractionRun, "_symsort", fake_symsort)
 
     with pytest.raises(IpswExtractError, match="boom"):
         extractor._symsort_sys_image()
@@ -616,7 +651,8 @@ def test_ipsw_aea_preflight_classifies_missing_key_failures(tmp_path: Path, monk
         archive.writestr("BuildManifest.plist", plistlib.dumps(build_manifest))
         archive.writestr("system.dmg.aea", b"dummy")
 
-    extractor = IpswExtractor(IpswPlatform.IPADOS, "iPad15,7_26.4.2_23E261_Restore.ipsw", processing_dir, ipsw_path)
+    request = IpswExtractionRequest(IpswPlatform.IPADOS, ipsw_path, processing_dir)
+    extractor = _IpswExtractionRun(request)
     pem_db = tmp_path / "fcs-keys.json"
     pem_db.write_text(json.dumps({"known-key": "known-value"}))
 

--- a/tests/test_ipsw_extract.py
+++ b/tests/test_ipsw_extract.py
@@ -6,7 +6,7 @@ from pydantic import HttpUrl
 
 from symx.fs import check_sha1
 from symx.ipsw.model import IpswSource, IpswPlatform, IpswArtifactHashes
-from symx.ipsw.extract import IpswExtractor
+from symx.ipsw.extract import IpswExtractionRequest, extract_ipsw
 
 
 def require_sha1(hashes: IpswArtifactHashes | None) -> str:
@@ -30,8 +30,8 @@ def test_ipsw_extract_run_watchos():
 
     with tempfile.TemporaryDirectory() as tmpdir:
         processing_dir = Path(tmpdir)
-        extractor = IpswExtractor(IpswPlatform.WATCHOS, source.file_name, processing_dir, ipsw_path)
-        extractor.run()
+        request = IpswExtractionRequest(IpswPlatform.WATCHOS, ipsw_path, processing_dir)
+        extract_ipsw(request)
 
 
 def test_ipsw_extract_run_ios():
@@ -49,8 +49,8 @@ def test_ipsw_extract_run_ios():
 
     processing_dir = Path("/Users/mischan/devel/tmp/test_out")
     ipsw_path = Path("/Users/mischan/devel/tmp/iPhone14,7_18.2_22C152_Restore.ipsw")
-    extractor = IpswExtractor(IpswPlatform.WATCHOS, source.file_name, processing_dir, ipsw_path)
-    extractor.run()
+    request = IpswExtractionRequest(IpswPlatform.WATCHOS, ipsw_path, processing_dir)
+    extract_ipsw(request)
 
 
 def test_ipsw_extract_run_macos():
@@ -109,5 +109,5 @@ def test_ipsw_extract_run_macos():
         processing_dir = Path(tmpdir)
         assert ipsw_path.stat().st_size == source.size
         assert check_sha1(require_sha1(source.hashes), ipsw_path)
-        extractor = IpswExtractor(IpswPlatform.MACOS, source.file_name, processing_dir, ipsw_path)
-        extractor.run()
+        request = IpswExtractionRequest(IpswPlatform.MACOS, ipsw_path, processing_dir, version="15.0", build="24A5279h")
+        extract_ipsw(request)

--- a/tests/test_ipsw_extract_runner.py
+++ b/tests/test_ipsw_extract_runner.py
@@ -12,6 +12,7 @@ from symx.ipsw.model import (
     IpswReleaseStatus,
     IpswSource,
 )
+from symx.ipsw.extract import IpswExtractionRequest
 from symx.ipsw.runners import ExtractionResult, extract
 from tests.fakes import FakeTimeout
 from tests.ipsw_storage_mock import InMemoryIpswStorage
@@ -22,29 +23,27 @@ class FakeExtractor:
 
     def __init__(self, should_fail: bool = False) -> None:
         self._should_fail = should_fail
-        self.extractions: list[tuple[IpswPlatform, str]] = []
+        self.extractions: list[IpswExtractionRequest] = []
         self.validate_called = False
 
     def validate_deps(self) -> None:
         self.validate_called = True
 
-    def extract(
-        self, platform: IpswPlatform, file_name: str, processing_dir: Path, ipsw_path: Path
-    ) -> ExtractionResult:
-        self.extractions.append((platform, file_name))
+    def extract(self, request: IpswExtractionRequest) -> ExtractionResult:
+        self.extractions.append(request)
 
         if self._should_fail:
             raise RuntimeError("extraction failed")
 
-        symbols_dir = processing_dir / "symbols"
+        symbols_dir = request.processing_dir / "symbols"
         symbols_dir.mkdir(parents=True, exist_ok=True)
         # Write a fake symbol binary
         (symbols_dir / "fake.sym").write_bytes(b"symbols")
 
-        bundle_id = f"ipsw_{file_name[:-5]}"
+        bundle_id = f"ipsw_{request.ipsw_path.name[:-5]}"
         return ExtractionResult(
             symbols_dir=symbols_dir,
-            prefix=str(platform).lower(),
+            prefix=str(request.platform).lower(),
             bundle_id=bundle_id,
         )
 
@@ -99,7 +98,14 @@ class TestExtractRunner:
 
         assert extractor.validate_called
         assert len(extractor.extractions) == 1
-        assert extractor.extractions[0] == (IpswPlatform.IOS, "iPhone_18.0_22A100_Restore.ipsw")
+        assert extractor.extractions[0] == IpswExtractionRequest(
+            platform=IpswPlatform.IOS,
+            ipsw_path=storage.local_dir / "iPhone_18.0_22A100_Restore.ipsw",
+            processing_dir=storage.local_dir,
+            version="18.0",
+            build="22A100",
+            devices=("iPhone15,2",),
+        )
 
         # Symbols were uploaded
         assert len(storage.uploaded_symbols) == 1
@@ -205,10 +211,8 @@ class TestExtractRunner:
 
         original_extract = extractor.extract
 
-        def extract_then_advance(
-            platform: IpswPlatform, file_name: str, processing_dir: Path, ipsw_path: Path
-        ) -> ExtractionResult:
-            result = original_extract(platform, file_name, processing_dir, ipsw_path)
+        def extract_then_advance(request: IpswExtractionRequest) -> ExtractionResult:
+            result = original_extract(request)
             timer.advance(11)
             return result
 


### PR DESCRIPTION
- The old public `IpswExtractor` class is gone, and implementation state lives in private `_IpswExtractionRun`
- `file_name` is no longer carried in the request. Bundle ID uses `request.ipsw_path.name`
- Workflow runner builds the request from authoritative metadata + downloaded local path
- `extract-file` builds the request from typed local IPSW inspection
- Also replaced the `BuildManifest.plist` cast soup with typed Pydantic subset models and `IpswDmgPaths`