### PR TITLE
fix: Batch IPSW meta-sync upserts with generation precondition

### DIFF
--- a/symx/ipsw/runners.py
+++ b/symx/ipsw/runners.py
@@ -22,6 +22,7 @@ from symx.ipsw.mirror import verify_download
 from symx.ipsw.storage import IpswStorage
 from symx.ipsw.storage.gcs import (
     IpswGcsStorage,
+    IpswMetaSnapshot,
     mirror_filter,
     extract_filter,
 )
@@ -84,7 +85,7 @@ def _set_artifact_context(artifact: IpswArtifact) -> None:
 
 def import_meta_from_appledb(ipsw_storage: "IpswGcsStorage") -> None:
     with sentry_sdk.start_span(op="ipsw.meta_sync", name="IPSW meta-sync from AppleDB"):
-        ipsw_storage.load_artifacts_meta()
+        _, base_generation = ipsw_storage.load_artifacts_meta()
 
         importer = AppleDbIpswImport(ipsw_storage.local_dir)
         importer.run()
@@ -94,8 +95,11 @@ def import_meta_from_appledb(ipsw_storage: "IpswGcsStorage") -> None:
 
         with sentry_sdk.start_span(op="ipsw.meta_sync.upsert", name="Upsert new artifacts") as upsert_span:
             upsert_span.set_data("count", len(importer.new_artifacts))
-            for artifact in importer.new_artifacts:
-                ipsw_storage.update_meta_item(artifact)
+            if importer.new_artifacts:
+                ipsw_storage.update_meta_items(
+                    importer.new_artifacts,
+                    base_snapshot=IpswMetaSnapshot(importer.meta_db, base_generation),
+                )
 
 
 def mirror(

--- a/symx/ipsw/storage/gcs.py
+++ b/symx/ipsw/storage/gcs.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 import shutil
+from dataclasses import dataclass
 from pathlib import Path
 from collections.abc import Callable, Iterable, Iterator, Sequence
 
@@ -26,6 +27,12 @@ from symx.ipsw.mirror import verify_download
 from symx.ipsw.storage import IpswStorage
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class IpswMetaSnapshot:
+    db: IpswArtifactDb
+    generation: int
 
 
 def _ipsw_artifact_sort_by_released(artifact: IpswArtifact) -> datetime.date:
@@ -69,17 +76,26 @@ class IpswGcsStorage(IpswStorage):
         self.client: Client = Client(project=self.project)
         self.bucket: Bucket = self.client.bucket(bucket)
 
-    def load_artifacts_meta(self) -> Blob:
-        artifacts_meta_blob = self.bucket.blob(ARTIFACTS_META_JSON)
-        if artifacts_meta_blob.exists():
-            artifacts_meta_blob.download_to_filename(str(self.local_artifacts_meta))
-        return artifacts_meta_blob
+    def load_artifacts_meta(self) -> tuple[Blob, int]:
+        """Download IPSW metadata and return the GCS write precondition generation.
 
-    def store_artifacts_meta(self, artifacts_meta_blob: Blob) -> None:
-        artifacts_meta_blob.upload_from_filename(
-            str(self.local_artifacts_meta),
-            if_generation_match=artifacts_meta_blob.generation,
-        )
+        The returned generation is 0 only when the remote object was observed as absent,
+        which makes the next upload create-only. Existing objects must have a concrete
+        generation; otherwise we cannot safely perform a conditional write.
+        """
+        artifacts_meta_blob = self.bucket.blob(ARTIFACTS_META_JSON)
+        if not artifacts_meta_blob.exists():
+            self.local_artifacts_meta.unlink(missing_ok=True)
+            return artifacts_meta_blob, 0
+
+        artifacts_meta_blob.download_to_filename(str(self.local_artifacts_meta))
+        generation = artifacts_meta_blob.generation
+        if generation is None:
+            artifacts_meta_blob.reload()
+            generation = artifacts_meta_blob.generation
+        if generation is None:
+            raise RuntimeError("Failed to determine IPSW meta-data generation after download")
+        return artifacts_meta_blob, generation
 
     def upload_ipsw(self, artifact: IpswArtifact, downloaded_source: tuple[Path, IpswSource]) -> IpswArtifact:
         ipsw_file, source = downloaded_source
@@ -121,9 +137,33 @@ class IpswGcsStorage(IpswStorage):
         return artifact
 
     def update_meta_item(self, ipsw_meta: IpswArtifact, retry: int = 5) -> IpswArtifactDb:
+        return self.update_meta_items([ipsw_meta], retry=retry)
+
+    def update_meta_items(
+        self,
+        ipsw_metas: Iterable[IpswArtifact],
+        *,
+        base_snapshot: IpswMetaSnapshot | None = None,
+        retry: int = 5,
+    ) -> IpswArtifactDb:
+        pending_metas = list(ipsw_metas)
+        if not pending_metas:
+            if base_snapshot is not None:
+                return base_snapshot.db
+            _, meta_db, _ = self.refresh_artifacts_db()
+            return meta_db
+
         while retry > 0:
-            blob, meta_db, generation = self.refresh_artifacts_db()
-            meta_db.upsert(ipsw_meta.key, ipsw_meta)
+            if base_snapshot is None:
+                blob, meta_db, generation = self.refresh_artifacts_db()
+            else:
+                blob = self.bucket.blob(ARTIFACTS_META_JSON)
+                meta_db = base_snapshot.db.model_copy(deep=True)
+                generation = base_snapshot.generation
+
+            for ipsw_meta in pending_metas:
+                meta_db.upsert(ipsw_meta.key, ipsw_meta)
+
             try:
                 blob.upload_from_string(
                     meta_db.model_dump_json(),
@@ -131,28 +171,23 @@ class IpswGcsStorage(IpswStorage):
                 )
                 return meta_db
             except PreconditionFailed:
+                base_snapshot = None
                 retry = retry - 1
 
-        raise RuntimeError("Failed to update meta-data item")
+        raise RuntimeError("Failed to update meta-data items")
 
     def refresh_artifacts_db(self) -> tuple[Blob, IpswArtifactDb, int]:
-        blob = self.load_artifacts_meta()
-        if blob.exists():
-            try:
-                fp = open(self.local_artifacts_meta)
-            except IOError:
-                meta_db, generation = IpswArtifactDb(), 0
-            else:
-                with fp:
-                    meta_db, generation = (
-                        IpswArtifactDb.model_validate_json(fp.read()),
-                        blob.generation,
-                    )
-        else:
-            meta_db, generation = IpswArtifactDb(), 0
+        blob, generation = self.load_artifacts_meta()
+        if generation == 0:
+            return blob, IpswArtifactDb(), generation
 
-        if generation is None:
-            generation = 0
+        try:
+            fp = open(self.local_artifacts_meta)
+        except IOError as e:
+            raise RuntimeError("Failed to read downloaded IPSW meta-data") from e
+
+        with fp:
+            meta_db = IpswArtifactDb.model_validate_json(fp.read())
         return blob, meta_db, generation
 
     def artifact_iter(

--- a/tests/test_ipsw_meta_updates.py
+++ b/tests/test_ipsw_meta_updates.py
@@ -1,0 +1,217 @@
+from datetime import date
+from typing import cast
+
+from google.cloud.exceptions import PreconditionFailed
+from google.cloud.storage import Blob, Bucket
+from pydantic import HttpUrl
+
+from symx.ipsw.model import IpswArtifact, IpswArtifactDb, IpswPlatform, IpswReleaseStatus, IpswSource
+from symx.ipsw.runners import import_meta_from_appledb
+from symx.ipsw.storage.gcs import IpswGcsStorage, IpswMetaSnapshot
+from symx.model import ArtifactProcessingState
+
+
+class _FakeBlob:
+    def __init__(
+        self,
+        *,
+        fail_upload: bool = False,
+        generation: int | None = None,
+        exists_result: bool = True,
+        reload_generation: int | None = None,
+    ) -> None:
+        self.fail_upload = fail_upload
+        self.generation = generation
+        self.exists_result = exists_result
+        self.reload_generation = reload_generation
+        self.downloads: list[str] = []
+        self.reload_count = 0
+        self.uploads: list[tuple[str, int]] = []
+
+    def exists(self) -> bool:
+        return self.exists_result
+
+    def download_to_filename(self, filename: str) -> None:
+        self.downloads.append(filename)
+        with open(filename, "w") as fp:
+            fp.write(IpswArtifactDb().model_dump_json())
+
+    def reload(self) -> None:
+        self.reload_count += 1
+        self.generation = self.reload_generation
+
+    def upload_from_string(self, payload: str, if_generation_match: int) -> None:
+        self.uploads.append((payload, if_generation_match))
+        if self.fail_upload:
+            self.fail_upload = False
+            raise PreconditionFailed("stale generation")
+
+
+class _FakeBucket:
+    def __init__(self, blob: _FakeBlob) -> None:
+        self.blob_calls: list[str] = []
+        self._blob = blob
+
+    def blob(self, name: str) -> _FakeBlob:
+        self.blob_calls.append(name)
+        return self._blob
+
+
+class _LoadOnlyIpswGcsStorage(IpswGcsStorage):
+    def __init__(self, local_dir, blob: _FakeBlob) -> None:
+        self.local_dir = local_dir
+        self.local_artifacts_meta = local_dir / "ipsw_meta.json"
+        self.bucket = cast(Bucket, _FakeBucket(blob))
+
+
+class _RefreshableIpswGcsStorage(IpswGcsStorage):
+    def __init__(
+        self, snapshots: list[tuple[_FakeBlob, IpswArtifactDb, int]], upload_blob: _FakeBlob | None = None
+    ) -> None:
+        self._snapshots = snapshots
+        self.refresh_count = 0
+        self.bucket = cast(Bucket, _FakeBucket(upload_blob or _FakeBlob()))
+
+    def refresh_artifacts_db(self) -> tuple[Blob, IpswArtifactDb, int]:
+        if not self._snapshots:
+            raise AssertionError("Unexpected meta-data refresh")
+        snapshot = self._snapshots[min(self.refresh_count, len(self._snapshots) - 1)]
+        self.refresh_count += 1
+        blob, meta_db, generation = snapshot
+        return cast(Blob, blob), meta_db, generation
+
+
+def _artifact(
+    version: str, build: str, state: ArtifactProcessingState = ArtifactProcessingState.INDEXED
+) -> IpswArtifact:
+    return IpswArtifact(
+        platform=IpswPlatform.IOS,
+        version=version,
+        build=build,
+        released=date(2025, 1, 1),
+        release_status=IpswReleaseStatus.RELEASE,
+        sources=[
+            IpswSource(
+                devices=["iPhone15,2"],
+                link=HttpUrl(f"https://updates.cdn-apple.com/iOS/iPhone_{version}_{build}_Restore.ipsw"),
+                processing_state=state,
+            )
+        ],
+    )
+
+
+def test_load_artifacts_meta_returns_zero_only_for_observed_absence(tmp_path) -> None:
+    stale_local_meta = tmp_path / "ipsw_meta.json"
+    stale_local_meta.write_text(IpswArtifactDb().model_dump_json())
+    blob = _FakeBlob(exists_result=False)
+    storage = _LoadOnlyIpswGcsStorage(tmp_path, blob)
+
+    loaded_blob, generation = storage.load_artifacts_meta()
+
+    assert loaded_blob is blob
+    assert generation == 0
+    assert not stale_local_meta.exists()
+    assert blob.downloads == []
+
+
+def test_load_artifacts_meta_reloads_unknown_existing_generation(tmp_path) -> None:
+    blob = _FakeBlob(exists_result=True, generation=None, reload_generation=321)
+    storage = _LoadOnlyIpswGcsStorage(tmp_path, blob)
+
+    loaded_blob, generation = storage.load_artifacts_meta()
+
+    assert loaded_blob is blob
+    assert generation == 321
+    assert blob.reload_count == 1
+    assert blob.downloads == [str(tmp_path / "ipsw_meta.json")]
+
+
+def test_update_meta_items_uploads_batch_from_base_without_refreshing() -> None:
+    base = IpswArtifactDb(artifacts={"existing": _artifact("18.0", "22A100")})
+    new_artifacts = [_artifact("18.1", "22B100"), _artifact("18.2", "22C100")]
+    blob = _FakeBlob()
+    storage = _RefreshableIpswGcsStorage([], upload_blob=blob)
+
+    updated = storage.update_meta_items(new_artifacts, base_snapshot=IpswMetaSnapshot(base, 123))
+
+    assert storage.refresh_count == 0
+    assert len(blob.uploads) == 1
+    payload, if_generation_match = blob.uploads[0]
+    assert if_generation_match == 123
+    uploaded_db = IpswArtifactDb.model_validate_json(payload)
+    assert set(uploaded_db.artifacts) == {"existing", "iOS_18.1_22B100", "iOS_18.2_22C100"}
+    assert set(updated.artifacts) == set(uploaded_db.artifacts)
+    assert set(base.artifacts) == {"existing"}
+
+
+def test_update_meta_items_refreshes_and_replays_batch_after_generation_conflict() -> None:
+    base = IpswArtifactDb(artifacts={"existing": _artifact("18.0", "22A100")})
+    concurrent = _artifact("18.0.1", "22A101", ArtifactProcessingState.MIRRORED)
+    latest = IpswArtifactDb(artifacts={"existing": _artifact("18.0", "22A100"), concurrent.key: concurrent})
+    new_artifacts = [_artifact("18.1", "22B100"), _artifact("18.2", "22C100")]
+    first_blob = _FakeBlob(fail_upload=True)
+    retry_blob = _FakeBlob()
+    storage = _RefreshableIpswGcsStorage([(retry_blob, latest, 124)], upload_blob=first_blob)
+
+    updated = storage.update_meta_items(new_artifacts, base_snapshot=IpswMetaSnapshot(base, 123))
+
+    assert storage.refresh_count == 1
+    assert first_blob.uploads[0][1] == 123
+    assert len(retry_blob.uploads) == 1
+    payload, if_generation_match = retry_blob.uploads[0]
+    assert if_generation_match == 124
+    uploaded_db = IpswArtifactDb.model_validate_json(payload)
+    assert set(uploaded_db.artifacts) == {"existing", concurrent.key, "iOS_18.1_22B100", "iOS_18.2_22C100"}
+    assert uploaded_db.artifacts[concurrent.key].sources[0].processing_state == ArtifactProcessingState.MIRRORED
+    assert set(updated.artifacts) == set(uploaded_db.artifacts)
+
+
+def test_import_meta_from_appledb_reuses_initial_generation_for_batch_upsert(tmp_path, monkeypatch) -> None:
+    class FakeImporter:
+        instances: list["FakeImporter"] = []
+
+        def __init__(self, processing_dir) -> None:
+            self.processing_dir = processing_dir
+            self.meta_db = IpswArtifactDb(artifacts={"existing": _artifact("18.0", "22A100")})
+            self.new_artifacts = [_artifact("18.1", "22B100"), _artifact("18.2", "22C100")]
+            self.run_called = False
+            self.instances.append(self)
+
+        def run(self) -> None:
+            self.run_called = True
+
+    class FakeStorage:
+        def __init__(self) -> None:
+            self.local_dir = tmp_path
+            self.load_count = 0
+            self.update_calls: list[tuple[list[IpswArtifact], IpswMetaSnapshot | None]] = []
+
+        def load_artifacts_meta(self) -> tuple[_FakeBlob, int]:
+            self.load_count += 1
+            return _FakeBlob(generation=456), 456
+
+        def update_meta_items(
+            self,
+            ipsw_metas,
+            *,
+            base_snapshot: IpswMetaSnapshot | None = None,
+        ) -> IpswArtifactDb:
+            self.update_calls.append((list(ipsw_metas), base_snapshot))
+            if base_snapshot is None:
+                return IpswArtifactDb()
+            return base_snapshot.db
+
+    monkeypatch.setattr("symx.ipsw.runners.AppleDbIpswImport", FakeImporter)
+    storage = FakeStorage()
+
+    import_meta_from_appledb(cast(IpswGcsStorage, storage))
+
+    importer = FakeImporter.instances[0]
+    assert importer.run_called is True
+    assert storage.load_count == 1
+    assert len(storage.update_calls) == 1
+    artifacts, base_snapshot = storage.update_calls[0]
+    assert artifacts == importer.new_artifacts
+    assert base_snapshot is not None
+    assert base_snapshot.db is importer.meta_db
+    assert base_snapshot.generation == 456


### PR DESCRIPTION
- batch IPSW AppleDB meta-sync upserts into one read/modify/write
- carry the initial metadata and its generation via a new `IpswMetaSnapshot`
- preserve GCS generation preconditions and refresh/replay on conflicts
- make `load_artifacts_meta()` return an explicit write precondition generation