### PR TITLE
gha: harden and harmonize workflow dependency management

### DIFF
--- a/.github/actions/install-ipsw/action.yml
+++ b/.github/actions/install-ipsw/action.yml
@@ -2,17 +2,9 @@ name: Install ipsw
 description: Install blacktop/ipsw from a GitHub release tarball.
 
 inputs:
-  version:
-    description: ipsw release version to install, without the leading v.
-    required: false
-    default: "3.1.685"
   platform:
     description: Release archive platform to install. Supported values are macos and linux.
     required: true
-  logs_root:
-    description: Directory for the install log consumed by failure notifications.
-    required: false
-    default: .github/logs
 
 runs:
   using: composite
@@ -20,42 +12,16 @@ runs:
     - name: Install ipsw
       shell: bash
       env:
-        IPSW_VERSION: ${{ inputs.version }}
         IPSW_PLATFORM: ${{ inputs.platform }}
-        IPSW_LOGS_ROOT: ${{ inputs.logs_root }}
+        IPSW_LOGS_ROOT: .github/logs
       run: |
         mkdir -p "$IPSW_LOGS_ROOT"
         set -o pipefail
         {
           set -euo pipefail
 
-          version="${IPSW_VERSION#v}"
-          if [ -z "$version" ]; then
-            echo "ipsw version input must not be empty"
-            exit 1
-          fi
-
-          case "$IPSW_PLATFORM" in
-            macos|darwin|macOS_universal)
-              archive_platform="macOS_universal"
-              ;;
-            linux|ubuntu|linux_x86_64)
-              archive_platform="linux_x86_64"
-              ;;
-            *)
-              echo "Unknown ipsw platform: $IPSW_PLATFORM"
-              echo "Expected one of: macos, linux"
-              exit 1
-              ;;
-          esac
-
-          tmp_dir="$(mktemp -d "${RUNNER_TEMP:-/tmp}/ipsw.XXXXXX")"
-          trap 'rm -rf "$tmp_dir"' EXIT
-          archive_path="$tmp_dir/ipsw.tar.gz"
-          archive_url="https://github.com/blacktop/ipsw/releases/download/v${version}/ipsw_${version}_${archive_platform}.tar.gz"
-
-          echo "Installing ipsw ${version} from ${archive_url}"
-          curl -LsSf --retry 6 --retry-delay 10 --retry-all-errors "$archive_url" -o "$archive_path"
-          sudo tar -xzf "$archive_path" -C /usr/local/bin ipsw
-          ipsw version
+          python3 "$GITHUB_ACTION_PATH/../../scripts/gha_deps.py" install-ipsw \
+            --platform "$IPSW_PLATFORM" \
+            --install-dir /usr/local/bin \
+            --sudo
         } 2>&1 | tee "$IPSW_LOGS_ROOT/install-ipsw.log"

--- a/.github/gha-deps.json
+++ b/.github/gha-deps.json
@@ -1,0 +1,44 @@
+{
+  "apple_root": {
+    "sha256": "b0b1730ecbc7ff4505142c49f1295e6eda6bcaed7e2c68c5be91b5a11001f024",
+    "url": "https://www.apple.com/appleca/AppleIncRootCertificate.cer"
+  },
+  "gcloud": {
+    "version": "575.0.0"
+  },
+  "ipsw": {
+    "archives": {
+      "linux_x86_64": "cabe6f36a13b60cd74f529bfe4ed0807905abae9d7ba798da380a4159cdde5e7",
+      "macOS_universal": "d86c4b6e0503a5119df5c5a8b183146e7e29f13bfaf8eec783b20b19f62171fe"
+    },
+    "version": "3.1.685"
+  },
+  "symsorter": {
+    "asset": "symsorter-Darwin-universal",
+    "sha256": "587a8994fd34665309d9b462e609ea1893996e4e4f0537fd439e8766ccf81fe1",
+    "symbolicator_version": "26.6.0"
+  },
+  "uv": {
+    "version": "0.11.26",
+    "wheel_hashes": {
+      "uv-0.11.26-py3-none-linux_armv6l.whl": "fb97bf04512dfe16d86084e75d8129701fc8da9fb40de8746b73c3aa617c5897",
+      "uv-0.11.26-py3-none-macosx_10_12_x86_64.whl": "a58a06e5a4b0035538d3ab4160ad74c716076ea7148eb3317171c6276ac020b4",
+      "uv-0.11.26-py3-none-macosx_11_0_arm64.whl": "7b6d078d2ce83897884c2330c0676f27be4bf3d223fb2a409460f579fb5f0a98",
+      "uv-0.11.26-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl": "1cd9ba4951681ce17f1703106266fcbe27aaa7d37f07d53cce8b5686d68a8755",
+      "uv-0.11.26-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl": "e4f4c3268e69ac96f01972274a62f5f930c03cbc680adba6f21e63237ba3a639",
+      "uv-0.11.26-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl": "efcbe0e187846f5ddba23bcaed17e4f9cd2463da5c45bdb5869616f686d713ff",
+      "uv-0.11.26-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl": "120ab2de93164d08cf5950f7fe18cbebe3ff670865ae41a292452bab2346477f",
+      "uv-0.11.26-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl": "9052bf27c7ee426901f35a48715fa9288ce631c1878b91c9a6c950288f4b8633",
+      "uv-0.11.26-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl": "efdddfcc9b1b790c5f7985c5c183c851682ced165b44ffa914f4947f5cad1fbf",
+      "uv-0.11.26-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl": "4dcf4e0b5b5cbdc242dcb002f1f8d99e7cf8c043609869228a9ce15e095c0b18",
+      "uv-0.11.26-py3-none-manylinux_2_28_aarch64.whl": "866ae8d28f7381c15de0906a284c1e97916424c635bf40f7960b3fc889cd725e",
+      "uv-0.11.26-py3-none-manylinux_2_31_riscv64.musllinux_1_1_riscv64.whl": "22f6d62e794b252ff3a1e2dfe5010cc76208f90b2c906e54971a0223ad6f16bc",
+      "uv-0.11.26-py3-none-manylinux_2_31_riscv64.whl": "edd0c12b75141a6d830d138a91e366ad66e630f1c1dcaf83b8325b80cbacfcbb",
+      "uv-0.11.26-py3-none-musllinux_1_1_i686.whl": "af6a45b11a569cc4d2437e89a25a53dcf753f2a02a8f2de96be09b9b942cb3ec",
+      "uv-0.11.26-py3-none-musllinux_1_1_x86_64.whl": "c28822517d03aebbe9549aaaecc88ad580e4b2b6a927abffe5774a74d6ba09f6",
+      "uv-0.11.26-py3-none-win32.whl": "79e5c1b3410047e1962290c3b7b8f512d2c1bb95200c60b016f7729287cf34c0",
+      "uv-0.11.26-py3-none-win_amd64.whl": "d95567e9470dc48ff03265f420c3c6973f6437f18a79d5e00b6eb4b2d9379907",
+      "uv-0.11.26-py3-none-win_arm64.whl": "7e69d1569afbb936e7bf4e4ab2f72d606405f4a68f380f088a0b2233e84e056a"
+    }
+  }
+}

--- a/.github/scripts/bootstrap-uv.sh
+++ b/.github/scripts/bootstrap-uv.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Source this file from GitHub Actions to install pinned uv and update PATH.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+bootstrap_env="$(python3 "$script_dir/gha_deps.py" bootstrap-uv --emit-shell)"
+eval "$bootstrap_env"

--- a/.github/scripts/gha_deps.py
+++ b/.github/scripts/gha_deps.py
@@ -1,0 +1,871 @@
+#!/usr/bin/env python3
+"""Manage pinned GitHub Actions bootstrap dependencies.
+
+This script intentionally uses only the Python standard library. It is called by
+GitHub Actions before project dependencies are installed, and it also provides
+operator-facing helpers for bumping the pins in .github/gha-deps.json.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shlex
+import shutil
+import site
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MANIFEST_PATH = REPO_ROOT / ".github" / "gha-deps.json"
+GITHUB_WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+CHUNK_SIZE = 1024 * 1024
+DEFAULT_RETRIES = 6
+DEFAULT_RETRY_DELAY_SECONDS = 10
+DEFAULT_TIMEOUT_SECONDS = 60
+
+IPSW_ARCHIVE_NAMES = {
+    "linux_x86_64": "linux_x86_64",
+    "macOS_universal": "macOS_universal",
+}
+IPSW_PLATFORM_ALIASES = {
+    "linux": "linux_x86_64",
+    "ubuntu": "linux_x86_64",
+    "linux_x86_64": "linux_x86_64",
+    "macos": "macOS_universal",
+    "darwin": "macOS_universal",
+    "macOS_universal": "macOS_universal",
+}
+
+
+class GhaDependencyError(RuntimeError):
+    """Raised for expected GitHub Actions dependency management failures."""
+
+
+def eprint(message: str) -> None:
+    print(message, file=sys.stderr)
+
+
+def require_sha256(value: str, *, label: str = "SHA-256") -> str:
+    normalized = value.lower()
+    if not re.fullmatch(r"[0-9a-f]{64}", normalized):
+        raise GhaDependencyError(f"{label} must be exactly 64 hex characters")
+    return normalized
+
+
+def require_https_url(url: str) -> None:
+    if not url.startswith("https://"):
+        raise GhaDependencyError(f"download URL must use https://: {url}")
+
+
+def load_manifest(path: Path = MANIFEST_PATH) -> dict[str, Any]:
+    return json.loads(path.read_text())
+
+
+def save_manifest(manifest: dict[str, Any], path: Path = MANIFEST_PATH) -> None:
+    path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+
+
+def manifest_section(manifest: dict[str, Any], name: str) -> dict[str, Any]:
+    section = manifest.get(name)
+    if not isinstance(section, dict):
+        raise GhaDependencyError(f"missing or invalid manifest section: {name}")
+    return section
+
+
+def manifest_str(section: dict[str, Any], key: str) -> str:
+    value = section.get(key)
+    if not isinstance(value, str) or not value:
+        raise GhaDependencyError(f"missing or invalid manifest value: {key}")
+    return value
+
+
+def manifest_str_map(section: dict[str, Any], key: str) -> dict[str, str]:
+    value = section.get(key)
+    if not isinstance(value, dict):
+        raise GhaDependencyError(f"missing or invalid manifest map: {key}")
+    result: dict[str, str] = {}
+    for item_key, item_value in value.items():
+        if not isinstance(item_key, str) or not isinstance(item_value, str):
+            raise GhaDependencyError(f"manifest map {key} must contain string keys and values")
+        result[item_key] = item_value
+    return result
+
+
+def request_for(url: str) -> urllib.request.Request:
+    require_https_url(url)
+    return urllib.request.Request(url, headers={"User-Agent": "symx-gha-deps"})
+
+
+def retrying_urlopen(url: str, *, timeout: int = DEFAULT_TIMEOUT_SECONDS) -> Any:
+    last_error: BaseException | None = None
+    for attempt in range(1, DEFAULT_RETRIES + 1):
+        try:
+            return urllib.request.urlopen(request_for(url), timeout=timeout)  # noqa: S310 - URL is required to be HTTPS.
+        except (OSError, TimeoutError, urllib.error.URLError) as error:
+            last_error = error
+            if attempt == DEFAULT_RETRIES:
+                break
+            eprint(
+                f"Download attempt {attempt}/{DEFAULT_RETRIES} failed for {url}: {error}; "
+                f"retrying in {DEFAULT_RETRY_DELAY_SECONDS}s"
+            )
+            time.sleep(DEFAULT_RETRY_DELAY_SECONDS)
+    raise GhaDependencyError(f"failed to download {url}: {last_error}")
+
+
+def fetch_json(url: str) -> dict[str, Any]:
+    with retrying_urlopen(url) as response:
+        data = json.load(response)
+    if not isinstance(data, dict):
+        raise GhaDependencyError(f"expected JSON object from {url}")
+    return data
+
+
+def fetch_text(url: str) -> str:
+    with retrying_urlopen(url) as response:
+        return response.read().decode("utf-8")
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        for chunk in iter(lambda: file.read(CHUNK_SIZE), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def sha256_url(url: str) -> str:
+    digest = hashlib.sha256()
+    with retrying_urlopen(url) as response:
+        while chunk := response.read(CHUNK_SIZE):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def download_url(url: str, output_path: Path) -> None:
+    eprint(f"Downloading {url}")
+    with retrying_urlopen(url) as response, output_path.open("wb") as output:
+        shutil.copyfileobj(response, output, length=CHUNK_SIZE)
+
+
+def runner_temp_dir(prefix: str) -> Path:
+    root = Path(os.environ.get("RUNNER_TEMP", tempfile.gettempdir()))
+    return Path(tempfile.mkdtemp(prefix=f"{prefix}.", dir=root))
+
+
+def download_verified(url: str, expected_sha256: str, output_path: Path) -> str:
+    expected_sha256 = require_sha256(expected_sha256)
+    temp_dir = runner_temp_dir("gha-deps-download")
+    try:
+        temp_path = temp_dir / "download"
+        download_url(url, temp_path)
+        actual_sha256 = sha256_file(temp_path)
+        if actual_sha256 != expected_sha256:
+            raise GhaDependencyError(
+                f"SHA-256 mismatch for {url}\n  expected: {expected_sha256}\n  actual:   {actual_sha256}"
+            )
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(temp_path), output_path)
+        eprint(f"Verified SHA-256: {actual_sha256}")
+        return actual_sha256
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def run_command(command: list[str], *, stdout_to_stderr: bool = False, env: dict[str, str] | None = None) -> None:
+    stdout = sys.stderr if stdout_to_stderr else None
+    subprocess.run(command, check=True, env=env, stdout=stdout, stderr=sys.stderr if stdout_to_stderr else None)
+
+
+def format_uv_requirements(version: str, wheel_hashes: dict[str, str]) -> str:
+    if not wheel_hashes:
+        raise GhaDependencyError("uv wheel hash list must not be empty")
+    hashes = [
+        require_sha256(value, label=f"uv hash for {filename}") for filename, value in sorted(wheel_hashes.items())
+    ]
+    lines = [
+        "# Generated from .github/gha-deps.json by .github/scripts/gha_deps.py.",
+        f"uv=={version} \\",
+    ]
+    for index, digest in enumerate(hashes):
+        suffix = " \\" if index < len(hashes) - 1 else ""
+        lines.append(f"    --hash=sha256:{digest}{suffix}")
+    return "\n".join(lines) + "\n"
+
+
+def uv_manifest_values(manifest: dict[str, Any]) -> tuple[str, dict[str, str]]:
+    uv_section = manifest_section(manifest, "uv")
+    return manifest_str(uv_section, "version"), manifest_str_map(uv_section, "wheel_hashes")
+
+
+def fetch_uv_wheel_hashes(version: str) -> dict[str, str]:
+    data = fetch_json(f"https://pypi.org/pypi/uv/{version}/json")
+    urls = data.get("urls")
+    if not isinstance(urls, list):
+        raise GhaDependencyError("PyPI uv response did not contain a urls list")
+    hashes: dict[str, str] = {}
+    for item in urls:
+        if not isinstance(item, dict) or item.get("packagetype") != "bdist_wheel":
+            continue
+        filename = item.get("filename")
+        digests = item.get("digests")
+        if not isinstance(filename, str) or not isinstance(digests, dict):
+            continue
+        sha256 = digests.get("sha256")
+        if isinstance(sha256, str):
+            hashes[filename] = require_sha256(sha256, label=f"uv hash for {filename}")
+    if not hashes:
+        raise GhaDependencyError(f"no uv wheel hashes found for {version}")
+    return hashes
+
+
+def install_uv(manifest: dict[str, Any], *, emit_shell: bool, print_bin_dir: bool) -> None:
+    version, wheel_hashes = uv_manifest_values(manifest)
+    temp_dir = runner_temp_dir("uv-bootstrap")
+    try:
+        requirements_path = temp_dir / "uv-bootstrap.txt"
+        requirements_path.write_text(format_uv_requirements(version, wheel_hashes))
+        env = os.environ.copy()
+        env["PIP_BREAK_SYSTEM_PACKAGES"] = "1"
+        run_command(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                "--user",
+                "--disable-pip-version-check",
+                "--no-deps",
+                "--only-binary=:all:",
+                "--require-hashes",
+                "-r",
+                str(requirements_path),
+            ],
+            stdout_to_stderr=emit_shell,
+            env=env,
+        )
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+    uv_bin_dir = str(Path(site.getuserbase()) / "bin")
+    github_path = os.environ.get("GITHUB_PATH")
+    if github_path:
+        with Path(github_path).open("a") as file:
+            file.write(uv_bin_dir + "\n")
+    if emit_shell:
+        print(f"export PATH={shlex.quote(uv_bin_dir)}:$PATH")
+    if print_bin_dir:
+        print(uv_bin_dir)
+
+
+def symbolicator_asset_url(version: str, asset: str) -> str:
+    return f"https://github.com/getsentry/symbolicator/releases/download/{version}/{asset}"
+
+
+def symsorter_manifest_values(manifest: dict[str, Any]) -> tuple[str, str, str]:
+    symsorter = manifest_section(manifest, "symsorter")
+    return (
+        manifest_str(symsorter, "symbolicator_version"),
+        manifest_str(symsorter, "asset"),
+        require_sha256(manifest_str(symsorter, "sha256"), label="symsorter SHA-256"),
+    )
+
+
+def install_symsorter(manifest: dict[str, Any], output: Path) -> None:
+    version, asset, expected_sha256 = symsorter_manifest_values(manifest)
+    download_verified(symbolicator_asset_url(version, asset), expected_sha256, output)
+    output.chmod(output.stat().st_mode | 0o111)
+    run_command(["file", str(output.resolve())])
+    run_command([str(output.resolve()), "--version"])
+
+
+def normalize_ipsw_platform(platform: str) -> str:
+    normalized = IPSW_PLATFORM_ALIASES.get(platform)
+    if normalized is None:
+        raise GhaDependencyError(f"Unknown ipsw platform: {platform}; expected one of: macos, linux")
+    return normalized
+
+
+def ipsw_archive_url(version: str, archive_platform: str) -> str:
+    return f"https://github.com/blacktop/ipsw/releases/download/v{version}/ipsw_{version}_{archive_platform}.tar.gz"
+
+
+def ipsw_manifest_values(manifest: dict[str, Any]) -> tuple[str, dict[str, str]]:
+    ipsw = manifest_section(manifest, "ipsw")
+    archives = manifest_str_map(ipsw, "archives")
+    for platform, digest in archives.items():
+        require_sha256(digest, label=f"ipsw {platform} SHA-256")
+    return manifest_str(ipsw, "version"), archives
+
+
+def install_ipsw(
+    manifest: dict[str, Any],
+    *,
+    platform: str,
+    install_dir: Path,
+    use_sudo: bool,
+) -> None:
+    version, manifest_archives = ipsw_manifest_values(manifest)
+    version = version.removeprefix("v")
+    if not version:
+        raise GhaDependencyError("ipsw version must not be empty")
+    archive_platform = normalize_ipsw_platform(platform)
+    expected_sha256 = manifest_archives.get(archive_platform)
+    if expected_sha256 is None:
+        raise GhaDependencyError(f"missing SHA-256 for ipsw {version} {archive_platform}")
+
+    temp_dir = runner_temp_dir("ipsw")
+    try:
+        archive_path = temp_dir / "ipsw.tar.gz"
+        url = ipsw_archive_url(version, archive_platform)
+        eprint(f"Installing ipsw {version} from {url}")
+        download_verified(url, expected_sha256, archive_path)
+        command = ["tar", "-xzf", str(archive_path), "-C", str(install_dir), "ipsw"]
+        if use_sudo:
+            command.insert(0, "sudo")
+        run_command(command)
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+    installed_ipsw = install_dir / "ipsw"
+    if installed_ipsw.exists():
+        run_command([str(installed_ipsw), "version"])
+    else:
+        run_command(["ipsw", "version"])
+
+
+def apple_root_manifest_values(manifest: dict[str, Any]) -> tuple[str, str]:
+    apple_root = manifest_section(manifest, "apple_root")
+    return (
+        manifest_str(apple_root, "url"),
+        require_sha256(manifest_str(apple_root, "sha256"), label="Apple root SHA-256"),
+    )
+
+
+def install_apple_root(manifest: dict[str, Any], *, cert_path: Path, crt_path: Path) -> None:
+    url, expected_sha256 = apple_root_manifest_values(manifest)
+    download_verified(url, expected_sha256, cert_path)
+    run_command(["openssl", "x509", "-inform", "DER", "-in", str(cert_path), "-out", str(crt_path)])
+    run_command(["sudo", "cp", str(crt_path), "/usr/local/share/ca-certificates"])
+    run_command(["sudo", "update-ca-certificates"])
+
+
+def fetch_ipsw_checksums(version: str) -> dict[str, str]:
+    checksum_url = f"https://github.com/blacktop/ipsw/releases/download/v{version}/checksums.txt"
+    return parse_ipsw_checksums(fetch_text(checksum_url), version)
+
+
+def parse_ipsw_checksums(checksums_text: str, version: str) -> dict[str, str]:
+    expected_names = {
+        platform: f"ipsw_{version}_{archive_name}.tar.gz" for platform, archive_name in IPSW_ARCHIVE_NAMES.items()
+    }
+    result: dict[str, str] = {}
+    for line in checksums_text.splitlines():
+        parts = line.split(maxsplit=1)
+        if len(parts) != 2:
+            continue
+        digest, filename = parts
+        for platform, expected_name in expected_names.items():
+            if filename == expected_name:
+                result[platform] = require_sha256(digest, label=f"ipsw {platform} SHA-256")
+    missing = sorted(set(expected_names) - set(result))
+    if missing:
+        raise GhaDependencyError(f"missing ipsw checksums for: {', '.join(missing)}")
+    return result
+
+
+def fetch_gcloud_latest_version() -> str:
+    data = fetch_json("https://dl.google.com/dl/cloudsdk/channels/rapid/components-2.json")
+    version = data.get("version")
+    if not isinstance(version, str) or not version:
+        raise GhaDependencyError("Cloud SDK metadata did not contain a version")
+    return version
+
+
+def update_setup_gcloud_text(text: str, version: str) -> tuple[str, int]:
+    lines = text.splitlines(keepends=True)
+    changed = 0
+    waiting_for_version = False
+    for index, line in enumerate(lines):
+        if "uses: google-github-actions/setup-gcloud@" in line:
+            waiting_for_version = True
+            continue
+        if waiting_for_version:
+            match = re.match(r'(?P<indent>\s*)version:\s*["\'][^"\']+["\'](?P<newline>\r?\n?)$', line)
+            if match:
+                lines[index] = f'{match.group("indent")}version: "{version}"{match.group("newline")}'
+                changed += 1
+                waiting_for_version = False
+            elif re.match(r"\s*-\s+name:", line):
+                waiting_for_version = False
+    return "".join(lines), changed
+
+
+def update_gcloud_workflows(version: str, *, write: bool) -> int:
+    total_changed = 0
+    for path in sorted(GITHUB_WORKFLOWS_DIR.glob("*.yml")):
+        text = path.read_text()
+        if "google-github-actions/setup-gcloud@" not in text:
+            continue
+        new_text, changed = update_setup_gcloud_text(text, version)
+        if changed:
+            total_changed += changed
+            print(f"{path.relative_to(REPO_ROOT)}: set Cloud SDK version to {version}")
+            if write:
+                path.write_text(new_text)
+    return total_changed
+
+
+def parse_ls_remote_output(output: str, tag: str) -> str:
+    direct_ref = f"refs/tags/{tag}"
+    peeled_ref = f"refs/tags/{tag}^{{}}"
+    direct_sha: str | None = None
+    peeled_sha: str | None = None
+    for line in output.splitlines():
+        parts = line.split()
+        if len(parts) != 2:
+            continue
+        sha, ref = parts
+        if ref == direct_ref:
+            direct_sha = sha
+        elif ref == peeled_ref:
+            peeled_sha = sha
+    resolved = peeled_sha or direct_sha
+    if resolved is None:
+        raise GhaDependencyError(f"could not resolve tag {tag}")
+    return resolved
+
+
+def resolve_action_tag(repo: str, tag: str) -> str:
+    result = subprocess.run(
+        [
+            "git",
+            "ls-remote",
+            f"https://github.com/{repo}.git",
+            f"refs/tags/{tag}",
+            f"refs/tags/{tag}^{{}}",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return parse_ls_remote_output(result.stdout, tag)
+
+
+def validate_manifest(manifest: dict[str, Any]) -> None:
+    uv_version, uv_hashes = uv_manifest_values(manifest)
+    if not uv_version:
+        raise GhaDependencyError("uv version must not be empty")
+    for filename, digest in uv_hashes.items():
+        require_sha256(digest, label=f"uv hash for {filename}")
+    gcloud = manifest_section(manifest, "gcloud")
+    manifest_str(gcloud, "version")
+    ipsw_manifest_values(manifest)
+    symsorter_manifest_values(manifest)
+    apple_root_manifest_values(manifest)
+
+
+def workflow_gcloud_versions() -> dict[Path, list[str]]:
+    versions: dict[Path, list[str]] = {}
+    version_re = re.compile(r'\s*version:\s*["\']([^"\']+)["\']')
+    for path in sorted(GITHUB_WORKFLOWS_DIR.glob("*.yml")):
+        text = path.read_text()
+        if "google-github-actions/setup-gcloud@" not in text:
+            continue
+        found: list[str] = []
+        waiting_for_version = False
+        for line in text.splitlines():
+            if "uses: google-github-actions/setup-gcloud@" in line:
+                waiting_for_version = True
+                continue
+            if waiting_for_version:
+                match = version_re.match(line)
+                if match:
+                    found.append(match.group(1))
+                    waiting_for_version = False
+                elif re.match(r"\s*-\s+name:", line):
+                    waiting_for_version = False
+        versions[path] = found
+    return versions
+
+
+def scan_static_policy() -> None:
+    disallowed_exact = [
+        "astral.sh/uv" + "/install.sh",
+        "releases/latest" + "/download",
+    ]
+    curl_word = "cu" + "rl"
+    wget_word = "w" + "get"
+    disallowed_regex = [
+        re.compile(rf"{curl_word}\s+.*\|\s*sh"),
+        re.compile(rf"\b{wget_word}\b"),
+    ]
+    roots = [REPO_ROOT / ".github" / "workflows", REPO_ROOT / ".github" / "actions"]
+    failures: list[str] = []
+    for root in roots:
+        for path in sorted(root.rglob("*")):
+            if not path.is_file():
+                continue
+            text = path.read_text(errors="ignore")
+            for needle in disallowed_exact:
+                if needle in text:
+                    failures.append(f"{path.relative_to(REPO_ROOT)} contains {needle}")
+            for pattern in disallowed_regex:
+                if pattern.search(text):
+                    failures.append(f"{path.relative_to(REPO_ROOT)} matches {pattern.pattern}")
+    if failures:
+        raise GhaDependencyError("static GitHub Actions dependency policy failures:\n" + "\n".join(failures))
+
+
+def verify(manifest: dict[str, Any], *, network: bool, large_downloads: bool) -> None:
+    validate_manifest(manifest)
+    scan_static_policy()
+    gcloud_version = manifest_str(manifest_section(manifest, "gcloud"), "version")
+    for path, versions in workflow_gcloud_versions().items():
+        if not versions:
+            raise GhaDependencyError(f"{path.relative_to(REPO_ROOT)} uses setup-gcloud without an explicit version")
+        for version in versions:
+            if version != gcloud_version:
+                raise GhaDependencyError(
+                    f"{path.relative_to(REPO_ROOT)} pins Cloud SDK {version}, expected {gcloud_version}"
+                )
+    print("Static GitHub Actions dependency policy checks passed.", flush=True)
+
+    if not network:
+        return
+
+    print("Verifying uv hash coverage for the current platform...", flush=True)
+    temp_dir = runner_temp_dir("uv-verify")
+    try:
+        uv_version, uv_hashes = uv_manifest_values(manifest)
+        requirements_path = temp_dir / "uv-bootstrap.txt"
+        requirements_path.write_text(format_uv_requirements(uv_version, uv_hashes))
+        run_command(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "download",
+                "--disable-pip-version-check",
+                "--no-deps",
+                "--only-binary=:all:",
+                "--require-hashes",
+                "-r",
+                str(requirements_path),
+                "-d",
+                str(temp_dir / "uv-download"),
+            ]
+        )
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+    print("Verifying Apple root certificate...", flush=True)
+    apple_url, apple_sha = apple_root_manifest_values(manifest)
+    if sha256_url(apple_url) != apple_sha:
+        raise GhaDependencyError("Apple root certificate hash mismatch")
+
+    print("Verifying symsorter release asset...", flush=True)
+    symsorter_version, symsorter_asset, symsorter_sha = symsorter_manifest_values(manifest)
+    if sha256_url(symbolicator_asset_url(symsorter_version, symsorter_asset)) != symsorter_sha:
+        raise GhaDependencyError("symsorter hash mismatch")
+
+    if large_downloads:
+        print("Verifying ipsw release archives...", flush=True)
+        ipsw_version, archives = ipsw_manifest_values(manifest)
+        for platform, expected_sha in sorted(archives.items()):
+            if sha256_url(ipsw_archive_url(ipsw_version, platform)) != expected_sha:
+                raise GhaDependencyError(f"ipsw {platform} hash mismatch")
+
+
+def print_manifest_update(name: str, old: Any, new: Any, *, write: bool) -> None:
+    action = "Updated" if write else "Would update"
+    print(f"{action} {name}:")
+    print(f"  old: {old}")
+    print(f"  new: {new}")
+
+
+def command_bootstrap_uv(args: argparse.Namespace) -> None:
+    install_uv(load_manifest(), emit_shell=args.emit_shell, print_bin_dir=args.print_bin_dir)
+
+
+def command_download_verified(args: argparse.Namespace) -> None:
+    download_verified(args.url, args.sha256, args.output)
+
+
+def command_install_symsorter(args: argparse.Namespace) -> None:
+    install_symsorter(load_manifest(), args.output)
+
+
+def command_install_ipsw(args: argparse.Namespace) -> None:
+    install_ipsw(
+        load_manifest(),
+        platform=args.platform,
+        install_dir=args.install_dir,
+        use_sudo=args.use_sudo,
+    )
+
+
+def command_install_apple_root(args: argparse.Namespace) -> None:
+    install_apple_root(load_manifest(), cert_path=args.cert_path, crt_path=args.crt_path)
+
+
+def command_uv_hashes(args: argparse.Namespace) -> None:
+    hashes = fetch_uv_wheel_hashes(args.version)
+    for filename, digest in sorted(hashes.items()):
+        print(filename, digest)
+
+
+def command_bump_uv(args: argparse.Namespace) -> None:
+    manifest = load_manifest()
+    old = manifest_section(manifest, "uv")
+    new = {"version": args.version, "wheel_hashes": fetch_uv_wheel_hashes(args.version)}
+    print_manifest_update("uv", old, new, write=args.write)
+    if args.write:
+        manifest["uv"] = new
+        save_manifest(manifest)
+
+
+def command_render_uv_requirements(args: argparse.Namespace) -> None:
+    version, hashes = uv_manifest_values(load_manifest())
+    print(format_uv_requirements(version, hashes), end="")
+
+
+def command_gcloud_latest(_: argparse.Namespace) -> None:
+    print(fetch_gcloud_latest_version())
+
+
+def command_bump_gcloud(args: argparse.Namespace) -> None:
+    version = fetch_gcloud_latest_version() if args.latest else args.version
+    if not version:
+        raise GhaDependencyError("provide --version or --latest")
+    manifest = load_manifest()
+    old = manifest_section(manifest, "gcloud")
+    new = {"version": version}
+    print_manifest_update("Google Cloud SDK", old, new, write=args.write)
+    changed = update_gcloud_workflows(version, write=args.write)
+    if changed == 0:
+        raise GhaDependencyError("no setup-gcloud version pins found to update")
+    if args.write:
+        manifest["gcloud"] = new
+        save_manifest(manifest)
+
+
+def command_ipsw_checksums(args: argparse.Namespace) -> None:
+    for platform, digest in sorted(fetch_ipsw_checksums(args.version).items()):
+        print(platform, digest)
+
+
+def command_bump_ipsw(args: argparse.Namespace) -> None:
+    manifest = load_manifest()
+    old = manifest_section(manifest, "ipsw")
+    new = {"version": args.version.removeprefix("v"), "archives": fetch_ipsw_checksums(args.version.removeprefix("v"))}
+    print_manifest_update("ipsw", old, new, write=args.write)
+    if args.write:
+        manifest["ipsw"] = new
+        save_manifest(manifest)
+
+
+def command_symsorter_sha(args: argparse.Namespace) -> None:
+    asset = args.asset
+    digest = sha256_url(symbolicator_asset_url(args.version, asset))
+    print(args.version, asset, digest)
+
+
+def command_bump_symsorter(args: argparse.Namespace) -> None:
+    asset = args.asset
+    digest = sha256_url(symbolicator_asset_url(args.version, asset))
+    manifest = load_manifest()
+    old = manifest_section(manifest, "symsorter")
+    new = {"symbolicator_version": args.version, "asset": asset, "sha256": digest}
+    print_manifest_update("symsorter", old, new, write=args.write)
+    if args.write:
+        manifest["symsorter"] = new
+        save_manifest(manifest)
+
+
+def command_resolve_action(args: argparse.Namespace) -> None:
+    print(resolve_action_tag(args.repo, args.tag))
+
+
+def command_apple_root_sha(args: argparse.Namespace) -> None:
+    manifest = load_manifest()
+    url, _ = apple_root_manifest_values(manifest)
+    if args.details:
+        temp_dir = runner_temp_dir("apple-root")
+        try:
+            cert_path = temp_dir / "AppleIncRootCertificate.cer"
+            download_url(url, cert_path)
+            print(sha256_file(cert_path))
+            run_command(
+                [
+                    "openssl",
+                    "x509",
+                    "-inform",
+                    "DER",
+                    "-in",
+                    str(cert_path),
+                    "-noout",
+                    "-subject",
+                    "-issuer",
+                    "-fingerprint",
+                    "-sha256",
+                ]
+            )
+        finally:
+            shutil.rmtree(temp_dir, ignore_errors=True)
+    else:
+        print(sha256_url(url))
+
+
+def command_bump_apple_root(args: argparse.Namespace) -> None:
+    manifest = load_manifest()
+    apple_root = manifest_section(manifest, "apple_root")
+    url = manifest_str(apple_root, "url")
+    digest = sha256_url(url)
+    old = dict(apple_root)
+    new = {"url": url, "sha256": digest}
+    print_manifest_update("Apple root certificate", old, new, write=args.write)
+    if args.write:
+        manifest["apple_root"] = new
+        save_manifest(manifest)
+
+
+def command_verify(args: argparse.Namespace) -> None:
+    verify(load_manifest(), network=args.network, large_downloads=args.large_downloads)
+
+
+def command_show(_: argparse.Namespace) -> None:
+    print(json.dumps(load_manifest(), indent=2, sort_keys=True))
+
+
+def add_write_flag(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--write", action="store_true", help="write changes instead of only printing the proposed update"
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    bootstrap_uv = subparsers.add_parser("bootstrap-uv", help="install the pinned uv bootstrap package")
+    bootstrap_uv.add_argument("--emit-shell", action="store_true", help="print shell code exporting uv's bin dir")
+    bootstrap_uv.add_argument("--print-bin-dir", action="store_true", help="print uv's bin dir")
+    bootstrap_uv.set_defaults(func=command_bootstrap_uv)
+
+    download = subparsers.add_parser("download-verified", help="download a URL and verify its SHA-256")
+    download.add_argument("url")
+    download.add_argument("sha256")
+    download.add_argument("output", type=Path)
+    download.set_defaults(func=command_download_verified)
+
+    symsorter = subparsers.add_parser("install-symsorter", help="install the pinned symsorter binary")
+    symsorter.add_argument("--output", type=Path, default=Path("symsorter"))
+    symsorter.set_defaults(func=command_install_symsorter)
+
+    ipsw = subparsers.add_parser("install-ipsw", help="install the pinned ipsw binary")
+    ipsw.add_argument("--platform", required=True)
+    ipsw.add_argument("--install-dir", type=Path, default=Path("/usr/local/bin"))
+    ipsw.add_argument("--sudo", dest="use_sudo", action="store_true", help="extract with sudo")
+    ipsw.set_defaults(func=command_install_ipsw)
+
+    apple_root = subparsers.add_parser("install-apple-root", help="install the pinned Apple root certificate")
+    apple_root.add_argument("--cert-path", type=Path, default=Path("AppleIncRootCertificate.cer"))
+    apple_root.add_argument("--crt-path", type=Path, default=Path("AppleIncRootCertificate.crt"))
+    apple_root.set_defaults(func=command_install_apple_root)
+
+    uv_hashes = subparsers.add_parser("uv-hashes", help="print PyPI wheel hashes for a uv version")
+    uv_hashes.add_argument("--version", required=True)
+    uv_hashes.set_defaults(func=command_uv_hashes)
+
+    bump_uv = subparsers.add_parser("bump-uv", help="update the uv manifest pin")
+    bump_uv.add_argument("--version", required=True)
+    add_write_flag(bump_uv)
+    bump_uv.set_defaults(func=command_bump_uv)
+
+    render_uv = subparsers.add_parser("render-uv-requirements", help="render the hashed uv requirements file")
+    render_uv.set_defaults(func=command_render_uv_requirements)
+
+    gcloud_latest = subparsers.add_parser("gcloud-latest", help="print the latest Google Cloud SDK rapid version")
+    gcloud_latest.set_defaults(func=command_gcloud_latest)
+
+    bump_gcloud = subparsers.add_parser("bump-gcloud", help="update the Cloud SDK manifest and workflow pins")
+    bump_gcloud.add_argument("--version")
+    bump_gcloud.add_argument("--latest", action="store_true")
+    add_write_flag(bump_gcloud)
+    bump_gcloud.set_defaults(func=command_bump_gcloud)
+
+    ipsw_checksums = subparsers.add_parser(
+        "ipsw-checksums", help="print workflow archive checksums for an ipsw version"
+    )
+    ipsw_checksums.add_argument("--version", required=True)
+    ipsw_checksums.set_defaults(func=command_ipsw_checksums)
+
+    bump_ipsw = subparsers.add_parser("bump-ipsw", help="update the ipsw manifest pin")
+    bump_ipsw.add_argument("--version", required=True)
+    add_write_flag(bump_ipsw)
+    bump_ipsw.set_defaults(func=command_bump_ipsw)
+
+    symsorter_sha = subparsers.add_parser("symsorter-sha", help="print the symsorter asset hash for a release")
+    symsorter_sha.add_argument("--version", required=True)
+    symsorter_sha.add_argument("--asset", default="symsorter-Darwin-universal")
+    symsorter_sha.set_defaults(func=command_symsorter_sha)
+
+    bump_symsorter = subparsers.add_parser("bump-symsorter", help="update the symsorter manifest pin")
+    bump_symsorter.add_argument("--version", required=True)
+    bump_symsorter.add_argument("--asset", default="symsorter-Darwin-universal")
+    add_write_flag(bump_symsorter)
+    bump_symsorter.set_defaults(func=command_bump_symsorter)
+
+    resolve_action = subparsers.add_parser("resolve-action", help="resolve a GitHub Action tag to a commit SHA")
+    resolve_action.add_argument("--repo", required=True, help="owner/repo")
+    resolve_action.add_argument("--tag", required=True)
+    resolve_action.set_defaults(func=command_resolve_action)
+
+    apple_root_sha = subparsers.add_parser("apple-root-sha", help="print the current Apple root certificate hash")
+    apple_root_sha.add_argument("--details", action="store_true", help="also print certificate details with openssl")
+    apple_root_sha.set_defaults(func=command_apple_root_sha)
+
+    bump_apple_root = subparsers.add_parser("bump-apple-root", help="update the Apple root certificate hash")
+    add_write_flag(bump_apple_root)
+    bump_apple_root.set_defaults(func=command_bump_apple_root)
+
+    verify_parser = subparsers.add_parser("verify", help="verify GitHub Actions dependency pins and policy")
+    verify_parser.add_argument("--network", action="store_true", help="also verify network-resolved hashes")
+    verify_parser.add_argument(
+        "--large-downloads", action="store_true", help="with --network, also download large ipsw archives"
+    )
+    verify_parser.set_defaults(func=command_verify)
+
+    show = subparsers.add_parser("show", help="print the GitHub Actions dependency manifest")
+    show.set_defaults(func=command_show)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        args.func(args)
+    except GhaDependencyError as error:
+        eprint(str(error))
+        return 1
+    except subprocess.CalledProcessError as error:
+        eprint(f"command failed with exit code {error.returncode}: {shlex.join(error.cmd)}")
+        return error.returncode or 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/bucket-runner.yml
+++ b/.github/workflows/bucket-runner.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
         with:
-          version: ">= 363.0.0"
+          version: "575.0.0"
 
       - name: ${{ inputs.bucket_step }}
         run: ${{ inputs.bucket_run }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -11,14 +11,13 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install dependencies
         run: |
-          curl -LsSf --retry 6 --retry-delay 10 --retry-all-errors https://astral.sh/uv/install.sh | sh
-          echo "PATH=/Users/runner/.local/bin:$PATH" >> $GITHUB_ENV
+          source .github/scripts/bootstrap-uv.sh
       - name: uv version
         run: uv --version
       - name: uv sync
         run: uv sync
       - name: ruff
-        run: uv run ruff check symx
+        run: uv run ruff check
       - name: ruff format
         run: uv run ruff format --check
       - name: pyright

--- a/.github/workflows/symx-admin-apply.yml
+++ b/.github/workflows/symx-admin-apply.yml
@@ -58,13 +58,11 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
         with:
-          version: ">= 363.0.0"
+          version: "575.0.0"
 
       - name: Install dependencies
         run: |
-          curl -LsSf --retry 6 --retry-delay 10 --retry-all-errors https://astral.sh/uv/install.sh | sh
-          echo "PATH=/home/runner/.local/bin:$PATH" >> "$GITHUB_ENV"
-          export PATH="/home/runner/.local/bin:$PATH"
+          source .github/scripts/bootstrap-uv.sh
           uv --version
           uv sync
 
@@ -75,7 +73,6 @@ jobs:
           SYMX_STORE: ${{ vars.SYMX_STORE }}
           REQUEST_JSON: ${{ inputs.request_json }}
         run: |
-          export PATH="/home/runner/.local/bin:$PATH"
           mkdir -p admin-apply
           uv run python -m symx admin apply-batch \
             --storage "$SYMX_STORE" \

--- a/.github/workflows/symx-admin-meta-sync.yml
+++ b/.github/workflows/symx-admin-meta-sync.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
         with:
-          version: ">= 363.0.0"
+          version: "575.0.0"
 
       - name: Compare remote generations
         id: compare

--- a/.github/workflows/symx-coverage-pages.yml
+++ b/.github/workflows/symx-coverage-pages.yml
@@ -28,9 +28,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          curl -LsSf --retry 6 --retry-delay 10 --retry-all-errors https://astral.sh/uv/install.sh | sh
-          echo "PATH=/home/runner/.local/bin:$PATH" >> "$GITHUB_ENV"
-          export PATH="/home/runner/.local/bin:$PATH"
+          source .github/scripts/bootstrap-uv.sh
           uv --version
           uv sync
 
@@ -39,7 +37,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SYMX_ADMIN_CACHE_DIR: ${{ runner.temp }}/symx-admin
         run: |
-          export PATH="/home/runner/.local/bin:$PATH"
           uv run symx admin sync --cache-dir "$SYMX_ADMIN_CACHE_DIR"
           uv run symx stats coverage-html \
             --cache-dir "$SYMX_ADMIN_CACHE_DIR" \

--- a/.github/workflows/symx-runner-macos.yml
+++ b/.github/workflows/symx-runner-macos.yml
@@ -48,7 +48,7 @@ jobs:
         continue-on-error: true
         uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
         with:
-          version: ">= 363.0.0"
+          version: "575.0.0"
 
       - name: Install dependencies
         id: install_dependencies
@@ -59,16 +59,10 @@ jobs:
           set -o pipefail
           {
             set -euo pipefail
-            curl -LsSf --retry 6 --retry-delay 10 --retry-all-errors https://astral.sh/uv/install.sh | sh
-            echo "PATH=/Users/runner/.local/bin:$PATH" >> $GITHUB_ENV
-            export PATH="/Users/runner/.local/bin:$PATH"
+            source .github/scripts/bootstrap-uv.sh
             uv --version
             uv sync
-            brew install tree
-            curl -LsSf --retry 6 --retry-delay 10 --retry-all-errors https://github.com/getsentry/symbolicator/releases/latest/download/symsorter-Darwin-universal > symsorter
-            chmod +x symsorter
-            file symsorter
-            ./symsorter --version
+            python3 .github/scripts/gha_deps.py install-symsorter --output symsorter
             pwd
             ls -la
           } 2>&1 | tee .github/logs/install-dependencies.log

--- a/.github/workflows/symx-runner-ubuntu.yml
+++ b/.github/workflows/symx-runner-ubuntu.yml
@@ -48,7 +48,7 @@ jobs:
         continue-on-error: true
         uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
         with:
-          version: ">= 363.0.0"
+          version: "575.0.0"
 
       - name: Install dependencies
         id: install_dependencies
@@ -59,9 +59,7 @@ jobs:
           set -o pipefail
           {
             set -euo pipefail
-            curl -LsSf --retry 6 --retry-delay 10 --retry-all-errors https://astral.sh/uv/install.sh | sh
-            echo "PATH=/Users/runner/.local/bin:$PATH" >> $GITHUB_ENV
-            export PATH="/Users/runner/.local/bin:$PATH"
+            source .github/scripts/bootstrap-uv.sh
             uv --version
             uv sync
           } 2>&1 | tee .github/logs/install-dependencies.log
@@ -83,10 +81,7 @@ jobs:
           set -o pipefail
           {
             set -euo pipefail
-            wget --tries=6 --waitretry=10 https://www.apple.com/appleca/AppleIncRootCertificate.cer
-            openssl x509 -inform DER -in AppleIncRootCertificate.cer -out AppleIncRootCertificate.crt
-            sudo cp AppleIncRootCertificate.crt /usr/local/share/ca-certificates
-            sudo update-ca-certificates
+            python3 .github/scripts/gha_deps.py install-apple-root
           } 2>&1 | tee .github/logs/install-apple-root.log
 
       - name: Cleanup runner-image

--- a/.github/workflows/symx-simulator-extract.yml
+++ b/.github/workflows/symx-simulator-extract.yml
@@ -43,7 +43,7 @@ jobs:
         continue-on-error: true
         uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
         with:
-          version: ">= 363.0.0"
+          version: "575.0.0"
 
       - name: Install dependencies
         id: install_dependencies
@@ -54,14 +54,10 @@ jobs:
           set -o pipefail
           {
             set -euo pipefail
-            curl -LsSf --retry 6 --retry-delay 10 --retry-all-errors https://astral.sh/uv/install.sh | sh
-            echo "PATH=/Users/runner/.local/bin:$PATH" >> $GITHUB_ENV
-            export PATH="/Users/runner/.local/bin:$PATH"
+            source .github/scripts/bootstrap-uv.sh
             uv --version
             uv sync
-            brew install tree
-            curl -LsSf --retry 6 --retry-delay 10 --retry-all-errors https://github.com/getsentry/symbolicator/releases/latest/download/symsorter-Darwin-universal > symsorter
-            chmod +x symsorter
+            python3 .github/scripts/gha_deps.py install-symsorter --output symsorter
             pwd
             ls -la
           } 2>&1 | tee .github/logs/install-dependencies.log

--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ More detail, including the "who processes what when" walkthrough and the state d
 | [`symx-admin-apply.yml`](https://github.com/getsentry/symx/blob/main/.github/workflows/symx-admin-apply.yml)             | Ubuntu              | Apply curated admin rerun batches               |
 | [`symx-coverage-pages.yml`](https://github.com/getsentry/symx/blob/main/.github/workflows/symx-coverage-pages.yml)       | Ubuntu              | Publish the coverage stats page to GitHub Pages |
 
-The workflow files in [`.github/workflows/`](.github/workflows/) are the authoritative deployment config.
+The workflow files in [`.github/workflows/`](.github/workflows/) are the authoritative deployment config. GitHub Actions bootstrap dependency pins and bump instructions live in
+[docs/gha-dependencies.md](docs/gha-dependencies.md).
 
 ## Quick start
 
@@ -172,6 +173,7 @@ Useful entry points:
 - Admin TUI and local SQLite snapshot: [docs/operations.md#admin-tui-and-local-snapshots](docs/operations.md#admin-tui-and-local-snapshots)
 - Sentry tags, transactions, and metrics: [docs/operations.md#sentry](docs/operations.md#sentry)
 - Failure-state diagrams: [docs/architecture.md#artifact-state-model](docs/architecture.md#artifact-state-model)
+- GitHub Actions dependency pins and bumping: [docs/gha-dependencies.md](docs/gha-dependencies.md)
 
 ## Current system boundaries and caveats
 

--- a/docs/gha-dependencies.md
+++ b/docs/gha-dependencies.md
@@ -1,0 +1,180 @@
+# GitHub Actions dependency pins
+
+GitHub Actions is part of the production execution path for Symx, so GitHub Actions bootstrap dependencies are pinned and verified instead of piping downloaded shell scripts into a shell or using floating `latest` URLs.
+
+The entrypoint for resolving, installing, verifying, and bumping GitHub Actions bootstrap dependencies is:
+
+```bash
+python3 .github/scripts/gha_deps.py --help
+```
+
+The pin manifest is [`.github/gha-deps.json`](../.github/gha-deps.json). The script is stdlib-only so workflows can run it before `uv sync`.
+
+## Current pin locations
+
+| Dependency                  | Source of truth                                                                             | Runtime use                                                                                                              |
+|-----------------------------|---------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|
+| Project Python dependencies | [`pyproject.toml`](../pyproject.toml) and [`uv.lock`](../uv.lock)                           | `uv sync`                                                                                                                |
+| `uv` bootstrap package      | `.github/gha-deps.json` `uv` section                                                        | [`.github/scripts/bootstrap-uv.sh`](../.github/scripts/bootstrap-uv.sh) calls `gha_deps.py bootstrap-uv`                 |
+| Google Cloud SDK            | `.github/gha-deps.json` `gcloud` section plus exact workflow `version:` pins                | `google-github-actions/setup-gcloud`                                                                                     |
+| `blacktop/ipsw` CLI         | `.github/gha-deps.json` `ipsw` section                                                      | [`.github/actions/install-ipsw/action.yml`](../.github/actions/install-ipsw/action.yml) calls `gha_deps.py install-ipsw` |
+| `symsorter`                 | `.github/gha-deps.json` `symsorter` section                                                 | `gha_deps.py install-symsorter`                                                                                          |
+| Apple root certificate      | `.github/gha-deps.json` `apple_root` section                                                | `gha_deps.py install-apple-root`                                                                                         |
+| GitHub Actions              | [`.github/workflows/`](../.github/workflows/) and [`.github/actions/`](../.github/actions/) | Third-party actions are pinned by commit SHA with the upstream tag in a comment.                                         |
+
+All direct GitHub Actions file downloads should go through `gha_deps.py`, which requires HTTPS and verifies SHA-256 before using downloaded content.
+
+## Runtime commands used by workflows
+
+```bash
+source .github/scripts/bootstrap-uv.sh
+python3 .github/scripts/gha_deps.py install-ipsw --platform macos --install-dir /usr/local/bin --sudo
+python3 .github/scripts/gha_deps.py install-ipsw --platform linux --install-dir /usr/local/bin --sudo
+python3 .github/scripts/gha_deps.py install-symsorter --output symsorter
+python3 .github/scripts/gha_deps.py install-apple-root
+```
+
+## Bumping project Python dependencies
+
+Use the standard project dependency workflow:
+
+```bash
+uv add <package>==<version>
+uv add --dev <package>==<version>
+uv remove <package>
+uv remove --dev <package>
+uv lock --upgrade-package <package>
+```
+
+Then run `uv sync` and the full verification suite.
+
+## Bumping `uv`
+
+Preview the hashes for a target version:
+
+```bash
+python3 .github/scripts/gha_deps.py uv-hashes --version 0.11.26
+```
+
+Preview and then apply the manifest update:
+
+```bash
+python3 .github/scripts/gha_deps.py bump-uv --version 0.11.26
+python3 .github/scripts/gha_deps.py bump-uv --version 0.11.26 --write
+```
+
+Validate the rendered hash-checked requirements for the current platform:
+
+```bash
+python3 .github/scripts/gha_deps.py verify --network
+```
+
+## Bumping Google Cloud SDK
+
+Check the current rapid channel version:
+
+```bash
+python3 .github/scripts/gha_deps.py gcloud-latest
+```
+
+Preview and then apply the manifest/workflow update:
+
+```bash
+python3 .github/scripts/gha_deps.py bump-gcloud --latest
+python3 .github/scripts/gha_deps.py bump-gcloud --latest --write
+```
+
+Use `--version <version>` instead of `--latest` to pin a specific version.
+
+## Bumping `ipsw`
+
+Preview the checksums for the two workflow archives:
+
+```bash
+python3 .github/scripts/gha_deps.py ipsw-checksums --version 3.1.685
+```
+
+Preview and then apply the manifest update:
+
+```bash
+python3 .github/scripts/gha_deps.py bump-ipsw --version 3.1.685
+python3 .github/scripts/gha_deps.py bump-ipsw --version 3.1.685 --write
+```
+
+Workflows should not override `ipsw` versions directly; update `.github/gha-deps.json` through `bump-ipsw` instead.
+
+## Bumping `symsorter`
+
+`symsorter` is released as part of `getsentry/symbolicator`.
+
+Preview the hash for a target release:
+
+```bash
+python3 .github/scripts/gha_deps.py symsorter-sha --version 26.6.0
+```
+
+Preview and then apply the manifest update:
+
+```bash
+python3 .github/scripts/gha_deps.py bump-symsorter --version 26.6.0
+python3 .github/scripts/gha_deps.py bump-symsorter --version 26.6.0 --write
+```
+
+## Bumping pinned GitHub Actions
+
+For each `uses: owner/repo@<sha> # <tag>` line:
+
+1. Pick the new upstream tag.
+2. Resolve the tag to a commit SHA:
+
+   ```bash
+   python3 .github/scripts/gha_deps.py resolve-action --repo actions/checkout --tag v6.0.2
+   ```
+
+3. Replace the SHA in the workflow/action file and update the trailing tag comment.
+
+The resolver uses the peeled commit for annotated tags.
+
+## Apple root certificate
+
+This should rarely change. If it does, inspect the current remote certificate:
+
+```bash
+python3 .github/scripts/gha_deps.py apple-root-sha --details
+```
+
+Preview and then apply the manifest update:
+
+```bash
+python3 .github/scripts/gha_deps.py bump-apple-root
+python3 .github/scripts/gha_deps.py bump-apple-root --write
+```
+
+## Verification after GitHub Actions dependency changes
+
+Run the GitHub Actions dependency policy check:
+
+```bash
+python3 .github/scripts/gha_deps.py verify
+```
+
+Add network verification for remotely resolved hashes. This downloads the current-platform `uv` wheel, the Apple root certificate, and `symsorter`:
+
+```bash
+python3 .github/scripts/gha_deps.py verify --network
+```
+
+To also re-download the larger pinned `ipsw` archives:
+
+```bash
+python3 .github/scripts/gha_deps.py verify --network --large-downloads
+```
+
+For code changes beyond workflow/docs bootstrap wiring, also run the full project suite from the repository root:
+
+```bash
+uv run ruff check --fix
+uv run ruff format
+uv run pyright
+uv run pytest
+```

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -309,10 +309,10 @@ It does the following:
 
 - checks out the repository,
 - authenticates to GCP via GitHub OIDC,
-- installs the Cloud SDK,
-- installs `uv` and Python dependencies,
-- installs the `ipsw` CLI,
-- installs the Apple root certificate,
+- installs the pinned Cloud SDK,
+- installs pinned `uv` and Python dependencies,
+- installs the pinned, checksum-verified `ipsw` CLI,
+- installs the checksum-verified Apple root certificate,
 - removes large preinstalled toolchains to free disk,
 - runs `scripts/run_symx_gha.py`.
 
@@ -326,10 +326,10 @@ It does the following:
 
 - checks out the repository,
 - authenticates to GCP via GitHub OIDC,
-- installs the Cloud SDK,
-- installs `uv` and Python dependencies,
-- installs the `ipsw` CLI,
-- downloads a platform-appropriate `symsorter` binary,
+- installs the pinned Cloud SDK,
+- installs pinned `uv` and Python dependencies,
+- installs the pinned, checksum-verified `ipsw` CLI,
+- downloads the pinned, checksum-verified `symsorter` binary,
 - runs `scripts/run_symx_gha.py`.
 
 This is used for extraction stages.

--- a/tests/test_gha_deps.py
+++ b/tests/test_gha_deps.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+def load_gha_deps() -> ModuleType:
+    path = Path(__file__).resolve().parents[1] / ".github" / "scripts" / "gha_deps.py"
+    spec = importlib.util.spec_from_file_location("gha_deps", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+gha_deps = load_gha_deps()
+
+
+def test_format_uv_requirements_sorts_hashes() -> None:
+    text = gha_deps.format_uv_requirements(
+        "1.2.3",
+        {
+            "uv-1.2.3-b.whl": "b" * 64,
+            "uv-1.2.3-a.whl": "a" * 64,
+        },
+    )
+
+    lines = text.splitlines()
+    assert lines[0] == "# Generated from .github/gha-deps.json by .github/scripts/gha_deps.py."
+    assert lines[1] == "uv==1.2.3 \\"
+    assert lines[2] == f"    --hash=sha256:{'a' * 64} \\"
+    assert lines[3] == f"    --hash=sha256:{'b' * 64}"
+
+
+def test_parse_ipsw_checksums_returns_workflow_archives() -> None:
+    linux_hash = "1" * 64
+    macos_hash = "2" * 64
+    checksums = f"""
+ignored malformed line
+{linux_hash}  ipsw_3.1.685_linux_x86_64.tar.gz
+{"3" * 64}  ipsw_3.1.685_linux_x86_64.tar.gz.sbom.json
+{macos_hash}  ipsw_3.1.685_macOS_universal.tar.gz
+"""
+
+    assert gha_deps.parse_ipsw_checksums(checksums, "3.1.685") == {
+        "linux_x86_64": linux_hash,
+        "macOS_universal": macos_hash,
+    }
+
+
+def test_parse_ipsw_checksums_requires_all_workflow_archives() -> None:
+    with pytest.raises(gha_deps.GhaDependencyError, match="missing ipsw checksums"):
+        gha_deps.parse_ipsw_checksums(f"{'1' * 64}  ipsw_3.1.685_linux_x86_64.tar.gz", "3.1.685")
+
+
+def test_parse_ls_remote_output_prefers_peeled_annotated_tag() -> None:
+    direct = "a" * 40
+    peeled = "b" * 40
+    output = f"{direct}\trefs/tags/v1.0.0\n{peeled}\trefs/tags/v1.0.0^{{}}\n"
+
+    assert gha_deps.parse_ls_remote_output(output, "v1.0.0") == peeled
+
+
+def test_parse_ls_remote_output_accepts_lightweight_tag() -> None:
+    direct = "a" * 40
+
+    assert gha_deps.parse_ls_remote_output(f"{direct}\trefs/tags/v1.0.0\n", "v1.0.0") == direct
+
+
+def test_update_setup_gcloud_text_updates_only_setup_gcloud_version() -> None:
+    text = """jobs:
+  test:
+    steps:
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@abc # v1
+        with:
+          version: \">= 363.0.0\"
+      - name: Other
+        with:
+          version: \"do-not-touch\"
+"""
+
+    new_text, changed = gha_deps.update_setup_gcloud_text(text, "575.0.0")
+
+    assert changed == 1
+    assert '          version: "575.0.0"' in new_text
+    assert '          version: "do-not-touch"' in new_text
+
+
+def test_normalize_ipsw_platform_aliases() -> None:
+    assert gha_deps.normalize_ipsw_platform("macos") == "macOS_universal"
+    assert gha_deps.normalize_ipsw_platform("linux") == "linux_x86_64"
+    with pytest.raises(gha_deps.GhaDependencyError, match="Unknown ipsw platform"):
+        gha_deps.normalize_ipsw_platform("windows")
+
+
+def test_download_verified_rejects_non_https_before_download(tmp_path: Path) -> None:
+    with pytest.raises(gha_deps.GhaDependencyError, match="https://"):
+        gha_deps.download_verified("http://example.com/file", "0" * 64, tmp_path / "file")
+
+
+def test_install_ipsw_requires_manifest_checksum_for_platform(tmp_path: Path) -> None:
+    manifest = {
+        "ipsw": {
+            "version": "3.1.685",
+            "archives": {"macOS_universal": "1" * 64},
+        }
+    }
+
+    with pytest.raises(gha_deps.GhaDependencyError, match="missing SHA-256"):
+        gha_deps.install_ipsw(
+            manifest,
+            platform="linux",
+            install_dir=tmp_path,
+            use_sudo=False,
+        )
+
+
+def test_repo_manifest_is_valid() -> None:
+    gha_deps.validate_manifest(gha_deps.load_manifest())


### PR DESCRIPTION
* single source of truth for http(s) workflow dependencies (`.github/gha-deps.json`)
* a single script (`.github/scripts/gha_deps.py`) used for
  * installing, previewing, and bumping `uv`, `gcloud`, `ipsw`, `symsorter`
  * bumping GitHub Actions
  * applying and bumping Apple root certs
  * verifying all sources
* rewrite all affected workflows and actions in terms of that single script
* minimize bash horrors everywhere (moar python + solely stdlib in GHA)