### PR TITLE
fix(ipsw): retry on transient fcs-key lookup failure

### DIFF
--- a/symx/ipsw/extract.py
+++ b/symx/ipsw/extract.py
@@ -7,6 +7,7 @@ import signal
 import stat
 import subprocess
 import tempfile
+import time
 import zipfile
 from collections.abc import Generator, Mapping
 from contextlib import contextmanager
@@ -53,6 +54,19 @@ _ERROR_SUMMARY_MARKERS = (
 _IGNORED_IPSW_HELP_PREFIXES = ("Usage:", "Aliases:", "Examples:", "Flags:", "Global Flags:")
 _FCS_KEY_URL_LABEL = "[com.apple.wkms.fcs-key-url]:"
 _VENDORED_PEM_DB = Path(__file__).resolve().parent / "data" / "fcs-keys.json"
+_AEA_KEY_MAX_ATTEMPTS = 3
+_AEA_KEY_RETRY_DELAY_SECONDS = 2
+_TRANSIENT_FCS_KEY_ERROR_MARKERS = (
+    "connection reset",
+    "connection refused",
+    "dial tcp",
+    "i/o timeout",
+    "network is unreachable",
+    "no such host",
+    "server misbehaving",
+    "temporary failure",
+    "tls handshake timeout",
+)
 _VERSION_MAJOR_RE = re.compile(r"^(\d+)")
 _MACOS_ROSETTA_DSC_MIN_MAJOR_VERSION = 27
 _ROSETTA_DSC_SOURCES = (
@@ -516,6 +530,13 @@ def _fcs_key_id_from_url(url: str | None) -> str | None:
     return key_id or None
 
 
+def _is_transient_fcs_key_error(stderr: str | bytes | None) -> bool:
+    text = decode_subprocess_output(stderr).lower()
+    if "failed to connect to fcs-key url" not in text:
+        return False
+    return any(marker in text for marker in _TRANSIENT_FCS_KEY_ERROR_MARKERS)
+
+
 def _compress_directory(directory: Path) -> Path:
     archive_path = directory.parent / f"{directory.name}.tar.zst"
 
@@ -665,13 +686,34 @@ class _IpswExtractionRun:
                     key_command.extend(["--pem-db", str(pem_db_path)])
                 key_command.append(str(extracted_aea))
 
-                key_result = subprocess.run(key_command, capture_output=True)
-                key_command_data = _ipsw_command_data(key_command, key_result.stdout, key_result.stderr, [temp_dir])
-                key_command_data.update(probe_data)
-                span.set_data("aea_key_probe", key_command_data)
-                if key_result.returncode != 0:
+                key_result: subprocess.CompletedProcess[bytes] | None = None
+                key_attempt_data: list[dict[str, object]] = []
+                for attempt in range(1, _AEA_KEY_MAX_ATTEMPTS + 1):
+                    key_result = subprocess.run(key_command, capture_output=True)
+                    key_command_data = _ipsw_command_data(key_command, key_result.stdout, key_result.stderr, [temp_dir])
+                    key_command_data.update(probe_data)
+                    key_command_data["attempt"] = attempt
+                    key_attempt_data.append(key_command_data)
+
+                    if key_result.returncode == 0:
+                        break
+                    if attempt == _AEA_KEY_MAX_ATTEMPTS or not _is_transient_fcs_key_error(key_result.stderr):
+                        break
+
+                    logger.warning(
+                        "Transient IPSW AEA FCS-key lookup failed for %s (attempt %d/%d), retrying",
+                        self.ipsw_path.name,
+                        attempt,
+                        _AEA_KEY_MAX_ATTEMPTS,
+                    )
+                    time.sleep(_AEA_KEY_RETRY_DELAY_SECONDS * attempt)
+
+                span.set_data("aea_key_probe", key_attempt_data[0] if len(key_attempt_data) == 1 else key_attempt_data)
+                if key_result is None or key_result.returncode != 0:
                     span.set_status("internal_error")
-                    summary = _summarize_ipsw_stderr(key_result.stderr) or "ipsw fw aea --key failed"
+                    summary = (
+                        _summarize_ipsw_stderr(key_result.stderr) if key_result is not None else None
+                    ) or "ipsw fw aea --key failed"
                     raise IpswExtractError(
                         f"IPSW AEA preflight failed for {self.ipsw_path}: "
                         f"selected_dmg={selected_dmg}; system_dmg={dmg_paths.system}; "

--- a/tests/test_extract_utils.py
+++ b/tests/test_extract_utils.py
@@ -11,7 +11,7 @@ import signal
 import subprocess
 import tempfile
 import zipfile
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from pathlib import Path
 from typing import BinaryIO, cast
@@ -792,7 +792,7 @@ def test_ipsw_symsort_sys_image_raises_on_mount_failure_and_cleans_mount_artifac
     assert not decrypted_dmg.exists()
 
 
-def test_ipsw_aea_preflight_classifies_missing_key_failures(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def _make_ipsw_aea_preflight_extractor(tmp_path: Path) -> _IpswExtractionRun:
     processing_dir = tmp_path / "processing"
     processing_dir.mkdir()
     ipsw_path = tmp_path / "test.ipsw"
@@ -813,11 +813,17 @@ def test_ipsw_aea_preflight_classifies_missing_key_failures(tmp_path: Path, monk
         archive.writestr("system.dmg.aea", b"dummy")
 
     request = IpswExtractionRequest(IpswPlatform.IPADOS, ipsw_path, processing_dir)
-    extractor = _IpswExtractionRun(request)
-    pem_db = tmp_path / "fcs-keys.json"
-    pem_db.write_text(json.dumps({"known-key": "known-value"}))
+    return _IpswExtractionRun(request)
+
+
+def _install_fake_aea_preflight_run(
+    monkeypatch: pytest.MonkeyPatch,
+    key_attempt_results: list[tuple[int, bytes, bytes]],
+) -> Callable[[], int]:
+    key_attempts = 0
 
     def fake_run(command: list[str], capture_output: bool = False) -> CompletedProcess[bytes]:
+        nonlocal key_attempts
         if "--info" in command:
             return CompletedProcess(
                 args=command,
@@ -828,27 +834,70 @@ def test_ipsw_aea_preflight_classifies_missing_key_failures(tmp_path: Path, monk
                 stderr=b"",
             )
 
-        return CompletedProcess(
-            args=command,
-            returncode=1,
-            stdout=b"",
-            stderr=b"\xe2\xa8\xaf failed to HPKE decrypt fcs-key: failed to connect to fcs-key URL: 403 Forbidden\n",
-        )
+        key_attempts += 1
+        returncode, stdout, stderr = key_attempt_results[key_attempts - 1]
+        return CompletedProcess(args=command, returncode=returncode, stdout=stdout, stderr=stderr)
+
+    monkeypatch.setattr("symx.ipsw.extract.subprocess.run", fake_run)
+    return lambda: key_attempts
+
+
+def test_ipsw_aea_preflight_classifies_missing_key_failures(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    extractor = _make_ipsw_aea_preflight_extractor(tmp_path)
+    pem_db = tmp_path / "fcs-keys.json"
+    pem_db.write_text(json.dumps({"known-key": "known-value"}))
+    get_key_attempts = _install_fake_aea_preflight_run(
+        monkeypatch,
+        [
+            (
+                1,
+                b"",
+                b"\xe2\xa8\xaf failed to HPKE decrypt fcs-key: failed to connect to fcs-key URL: 403 Forbidden\n",
+            )
+        ],
+    )
 
     monkeypatch.setattr("symx.ipsw.extract.vendored_ipsw_pem_db_path", lambda: pem_db)
     monkeypatch.setattr("symx.ipsw.extract._vendored_ipsw_pem_db_keys", lambda: frozenset({"known-key"}))
-    monkeypatch.setattr("symx.ipsw.extract.subprocess.run", fake_run)
 
     with pytest.raises(IpswExtractError, match="IPSW AEA preflight failed") as exc_info:
         extractor._ipsw_aea_preflight()
 
     message = str(exc_info.value)
+    assert get_key_attempts() == 1
     assert "selected_dmg=system.dmg.aea" in message
     assert "system_dmg=system.dmg.aea" in message
     assert "filesystem_dmg=filesystem.dmg.aea" in message
     assert "fcs_key=missing-key=" in message
     assert "vendored_db_hit=False" in message
     assert "failed to HPKE decrypt fcs-key: failed to connect to fcs-key URL: 403 Forbidden" in message
+
+
+def test_ipsw_aea_preflight_retries_transient_fcs_key_lookup(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    extractor = _make_ipsw_aea_preflight_extractor(tmp_path)
+    get_key_attempts = _install_fake_aea_preflight_run(
+        monkeypatch,
+        [
+            (
+                1,
+                b"",
+                (
+                    b"\xe2\xa8\xaf failed to HPKE decrypt fcs-key: failed to connect to fcs-key URL: "
+                    b'Get "https://wkms-public.apple.com/fcs-keys/missing-key=": '
+                    b"dial tcp: lookup wkms-public.apple.com: no such host\n"
+                ),
+            ),
+            (0, b"key", b""),
+        ],
+    )
+
+    monkeypatch.setattr("symx.ipsw.extract.vendored_ipsw_pem_db_path", lambda: None)
+    monkeypatch.setattr("symx.ipsw.extract._vendored_ipsw_pem_db_keys", lambda: frozenset())
+    monkeypatch.setattr("symx.ipsw.extract.time.sleep", lambda seconds: None)
+
+    extractor._ipsw_aea_preflight()
+
+    assert get_key_attempts() == 2
 
 
 def test_ipsw_extract_dsc_includes_stderr_summary_when_available(


### PR DESCRIPTION
- Identify transient FCS-key lookup failures by checking against error markers in the `ipsw` output.
- Retry for a hard-coded number of times (currently 3x) and wait for a predefined delay (currently 2 seconds), multiplied by the attempt number
- Only raise if we exhausted the attempts