### PR TITLE
fix(ota): classify unsupported AEA payload DSC references

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -151,7 +151,7 @@ Special OTA-only exits:
 
 - `delta_ota` – the payload is a delta/patch OTA and does not contain a full DSC.
 - `recovery_ota` – the payload is a recovery OTA and does not contain a usable DSC.
-- `unsupported_ota_payload` – the OTA appears to reference a full DSC, but the current payloadv2/Apple Archive tooling cannot materialize it.
+- `unsupported_ota_payload` – the OTA references a DSC in payload listings or BOM metadata, but the current payloadv2/Apple Archive tooling cannot materialize it. For BOM-only AEA evidence, this is a tooling-limitation classification rather than proof that the OTA contains every DSC byte.
 
 If the mirrored OTA is missing when extraction starts, Symx resets it back to `indexed` and clears `download_path` so a later mirror run can fetch it again.
 
@@ -355,20 +355,20 @@ The shared enum lives in [`symx/model.py`](../symx/model.py).
 
 Not all states are emitted by current automation. The table below reflects current code behavior.
 
-| State                      | Meaning                                                                                 | Current automated emitters                   | Notes                                                                               |
-|----------------------------|-----------------------------------------------------------------------------------------|----------------------------------------------|-------------------------------------------------------------------------------------|
-| `indexed`                  | Known to Symx and eligible for processing                                               | IPSW sync, OTA merge, OTA extract reset path | Starting point for new work                                                         |
-| `indexed_duplicate`        | Equivalent payload already represented elsewhere; skip duplicate processing             | OTA merge                                    | Current OTA-only duplicate suppression path                                         |
-| `indexed_invalid`          | Metadata exists, but the artifact could not be mirrored reliably                        | OTA mirror                                   | Defined generically, but current IPSW mirror uses `mirroring_failed` instead        |
-| `mirrored`                 | Artifact payload is present in GCS mirror storage                                       | IPSW mirror, OTA mirror                      | Input state for extraction                                                          |
-| `mirroring_failed`         | Apple download or verification failed during IPSW mirroring                             | IPSW mirror                                  | Current IPSW failure state for mirror-stage problems                                |
-| `mirror_corrupt`           | Metadata points at a mirror object that cannot be downloaded or verified                | IPSW extract                                 | Current IPSW-only emitted state                                                     |
-| `delta_ota`                | OTA is a delta/patch update and has no full DSC                                         | OTA extract                                  | Expected terminal-ish skip state, not an error                                      |
-| `recovery_ota`             | OTA is a recovery image and has no usable DSC                                           | OTA extract                                  | Expected terminal-ish skip state, not an error                                      |
-| `unsupported_ota_payload`  | OTA appears to reference a full DSC, but current tooling cannot materialize the payload | OTA extract                                  | Terminal for current automation, but semantically distinct from delta/recovery OTAs |
-| `symbols_extracted`        | Symbols were uploaded successfully                                                      | IPSW extract, OTA extract                    | Desired success state                                                               |
-| `symbol_extraction_failed` | Extraction, splitting, symsort, or symbol upload failed                                 | IPSW extract, OTA extract                    | Current main recovery state                                                         |
-| `ignored`                  | Manually excluded from processing                                                       | none                                         | Manual/operator-only concept; current automation does not assign it                 |
+| State                      | Meaning                                                                                          | Current automated emitters                   | Notes                                                                                             |
+|----------------------------|--------------------------------------------------------------------------------------------------|----------------------------------------------|---------------------------------------------------------------------------------------------------|
+| `indexed`                  | Known to Symx and eligible for processing                                                        | IPSW sync, OTA merge, OTA extract reset path | Starting point for new work                                                                       |
+| `indexed_duplicate`        | Equivalent payload already represented elsewhere; skip duplicate processing                      | OTA merge                                    | Current OTA-only duplicate suppression path                                                       |
+| `indexed_invalid`          | Metadata exists, but the artifact could not be mirrored reliably                                 | OTA mirror                                   | Defined generically, but current IPSW mirror uses `mirroring_failed` instead                      |
+| `mirrored`                 | Artifact payload is present in GCS mirror storage                                                | IPSW mirror, OTA mirror                      | Input state for extraction                                                                        |
+| `mirroring_failed`         | Apple download or verification failed during IPSW mirroring                                      | IPSW mirror                                  | Current IPSW failure state for mirror-stage problems                                              |
+| `mirror_corrupt`           | Metadata points at a mirror object that cannot be downloaded or verified                         | IPSW extract                                 | Current IPSW-only emitted state                                                                   |
+| `delta_ota`                | OTA is a delta/patch update and has no full DSC                                                  | OTA extract                                  | Expected terminal-ish skip state, not an error                                                    |
+| `recovery_ota`             | OTA is a recovery image and has no usable DSC                                                    | OTA extract                                  | Expected terminal-ish skip state, not an error                                                    |
+| `unsupported_ota_payload`  | OTA references a DSC in payload/BOM metadata, but current tooling cannot materialize the payload | OTA extract                                  | Terminal for current automation; BOM-only evidence may describe post-state files for partial OTAs |
+| `symbols_extracted`        | Symbols were uploaded successfully                                                               | IPSW extract, OTA extract                    | Desired success state                                                                             |
+| `symbol_extraction_failed` | Extraction, splitting, symsort, or symbol upload failed                                          | IPSW extract, OTA extract                    | Current main recovery state                                                                       |
+| `ignored`                  | Manually excluded from processing                                                                | none                                         | Manual/operator-only concept; current automation does not assign it                               |
 
 ## 5.1 IPSW source state diagram
 
@@ -421,7 +421,7 @@ stateDiagram-v2
 - The persisted state lives directly on each **`OtaArtifact`**.
 - OTA metadata merge preserves `processing_state` and `download_path` for already-known artifacts.
 - `iter_mirror()` always reloads metadata and prefers the newest mirrored OTA first.
-- `unsupported_ota_payload` is a terminal skip state distinct from `delta_ota` / `recovery_ota`: the OTA appears to reference a DSC, but current tooling cannot extract it.
+- `unsupported_ota_payload` is a terminal skip state distinct from `delta_ota` / `recovery_ota`: the OTA references a DSC in payload/BOM metadata, but current tooling cannot materialize it. BOM-only evidence may describe post-state files rather than proving every DSC byte is present in the OTA.
 - The current `ota migrate-storage` path resets **all** OTAs in `symbol_extraction_failed` back to `mirrored`.
 
 ## 5.3 Manual-only and domain-specific nuances

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -598,7 +598,7 @@ They mean the OTA does not contain a full DSC that Symx can process.
 
 This is also usually a terminal skip state rather than an operator emergency.
 
-It means the OTA appears to reference a full DSC, but the current payloadv2 / Apple Archive tooling cannot materialize it. In other words, this is different from delta or recovery OTAs: the DSC seems to exist conceptually, but current automation cannot extract it.
+It means the OTA references a DSC in payload listings or BOM/post-state metadata, but the current payloadv2 / Apple Archive tooling cannot materialize or verify it. In AEA BOM-only cases, this does not prove that every DSC byte is present in the OTA; it separates known payload tooling limitations from unknown extraction failures.
 
 ## 5. Current recovery mechanisms
 

--- a/symx/ota/extract.py
+++ b/symx/ota/extract.py
@@ -41,12 +41,17 @@ PAYLOAD_FILE_NAME_RE = re.compile(r"(^|.*/)payloadv2/payload\.\d+$")
 DYLD_BOM_ENTRY_RE = re.compile(
     r"^(?:\./)?(?:System/DriverKit/)?System/Library/(?:dyld|Caches/com\.apple\.dyld)/dyld_shared_cache_[^\s/]+$"
 )
+DYLD_LISTING_ENTRY_RE = re.compile(
+    r"(?:\./)?(?:System/DriverKit/)?System/Library/(?:dyld|Caches/com\.apple\.dyld)/dyld_shared_cache_[^\s/]+"
+)
 DYLD_AA_INCLUDE_REGEX = r"(System/DriverKit/)?System/Library/(dyld|Caches/com\.apple\.dyld)/dyld_shared_cache_"
 UNSUPPORTED_AA_ERROR_MARKERS = (
     "invalid/non-supported archive stream",
     "archive stream read error (header)",
 )
 MAX_AA_PROBE_OUTPUT_CHARS = 500
+MAX_IPSW_LISTING_PROBE_OUTPUT_CHARS = 1000
+AEA_MAGIC = b"AEA1"
 _ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*m")
 _LEADING_IPSW_GLYPH_RE = re.compile(r"^\s*[•⨯]\s*")
 _OTA_ERROR_SUMMARY_MARKERS = (
@@ -66,6 +71,13 @@ class PayloadAaProbeResult(TypedDict):
     stderr: str | None
     extracted_count: int
     unsupported_error: bool
+
+
+class PayloadListingProbeResult(TypedDict):
+    returncode: int
+    stdout: str | None
+    stderr: str | None
+    dsc_entries: list[str]
 
 
 def _extract_dirs_data(output_dir: Path) -> list[dict[str, object]]:
@@ -102,6 +114,14 @@ def _should_probe_unsupported_payload(error: OtaExtractError) -> bool:
 def _ota_is_zip_archive(artifact: Path) -> bool:
     try:
         return zipfile.is_zipfile(artifact)
+    except OSError:
+        return False
+
+
+def _ota_is_aea_archive(artifact: Path) -> bool:
+    try:
+        with artifact.open("rb") as f:
+            return f.read(len(AEA_MAGIC)) == AEA_MAGIC
     except OSError:
         return False
 
@@ -168,6 +188,44 @@ def _probe_payload_with_aa(artifact: Path, payload_name: str, pattern: str) -> P
         }
 
 
+def _dsc_entries_from_ipsw_listing(output: str) -> list[str]:
+    entries: list[str] = []
+    for raw_line in _strip_ansi(output).splitlines():
+        line = _normalize_ipsw_output_line(raw_line)
+        match = DYLD_LISTING_ENTRY_RE.search(line)
+        if match:
+            entries.append(match.group(0).removeprefix("./"))
+    return entries
+
+
+def _probe_aea_bom_listing_for_dsc(artifact: Path) -> PayloadListingProbeResult:
+    result = subprocess.run(
+        ["ipsw", "ota", "ls", str(artifact), "--bom"],
+        capture_output=True,
+        text=True,
+    )
+    return {
+        "returncode": result.returncode,
+        "stdout": truncate_text(result.stdout, max_chars=MAX_IPSW_LISTING_PROBE_OUTPUT_CHARS),
+        "stderr": truncate_text(result.stderr, max_chars=MAX_IPSW_LISTING_PROBE_OUTPUT_CHARS),
+        "dsc_entries": _dsc_entries_from_ipsw_listing(result.stdout),
+    }
+
+
+def _probe_aea_payload_listing_for_dsc(artifact: Path) -> PayloadListingProbeResult:
+    result = subprocess.run(
+        ["ipsw", "ota", "ls", str(artifact), "--payload", "--pattern", DYLD_SHARED_CACHE],
+        capture_output=True,
+        text=True,
+    )
+    return {
+        "returncode": result.returncode,
+        "stdout": truncate_text(result.stdout, max_chars=MAX_IPSW_LISTING_PROBE_OUTPUT_CHARS),
+        "stderr": truncate_text(result.stderr, max_chars=MAX_IPSW_LISTING_PROBE_OUTPUT_CHARS),
+        "dsc_entries": _dsc_entries_from_ipsw_listing(result.stdout),
+    }
+
+
 def _probe_unsupported_payload_format(artifact: Path) -> bool:
     with sentry_sdk.start_span(op="ota.extract.payload_probe", name="Probe unsupported OTA payload") as span:
         span.set_data("artifact", str(artifact))
@@ -175,9 +233,47 @@ def _probe_unsupported_payload_format(artifact: Path) -> bool:
         try:
             if not _ota_is_zip_archive(artifact):
                 span.set_data("is_zip_archive", False)
-                return False
+                is_aea_archive = _ota_is_aea_archive(artifact)
+                span.set_data("is_aea_archive", is_aea_archive)
+                if not is_aea_archive:
+                    return False
+
+                payload_listing = _probe_aea_payload_listing_for_dsc(artifact)
+                payload_dsc_entries = payload_listing["dsc_entries"]
+                span.set_data(
+                    "aea_payload_listing_probe",
+                    {
+                        "returncode": payload_listing["returncode"],
+                        "stdout": payload_listing["stdout"],
+                        "stderr": payload_listing["stderr"],
+                        "dsc_entry_count": len(payload_dsc_entries),
+                        "dsc_entries_sample": payload_dsc_entries[:10],
+                    },
+                )
+                if payload_listing["returncode"] == 0 and payload_dsc_entries:
+                    span.set_data("unsupported_payload_format", True)
+                    return True
+
+                # `ipsw ota ls --bom` can describe post-state files for partial OTAs, so BOM matches are
+                # evidence that the OTA references a DSC, not proof that every DSC byte is present.
+                bom_listing = _probe_aea_bom_listing_for_dsc(artifact)
+                bom_dsc_entries = bom_listing["dsc_entries"]
+                span.set_data(
+                    "aea_bom_listing_probe",
+                    {
+                        "returncode": bom_listing["returncode"],
+                        "stdout": bom_listing["stdout"],
+                        "stderr": bom_listing["stderr"],
+                        "dsc_entry_count": len(bom_dsc_entries),
+                        "dsc_entries_sample": bom_dsc_entries[:10],
+                    },
+                )
+                unsupported = bom_listing["returncode"] == 0 and bool(bom_dsc_entries)
+                span.set_data("unsupported_payload_format", unsupported)
+                return unsupported
 
             span.set_data("is_zip_archive", True)
+            span.set_data("is_aea_archive", False)
             bom_matches = _read_post_bom_dsc_matches(artifact)
             span.set_data("post_bom_dsc_match_count", len(bom_matches))
             span.set_data("post_bom_dsc_matches", bom_matches[:10])

--- a/symx/ota/model.py
+++ b/symx/ota/model.py
@@ -179,7 +179,7 @@ class RecoveryOtaError(Exception):
 
 
 class UnsupportedOtaPayloadError(Exception):
-    """Raised when an OTA references a DSC but current tooling cannot extract its payload format."""
+    """Raised when an OTA references a DSC but current tooling cannot materialize it."""
 
     pass
 

--- a/symx/ota/runners.py
+++ b/symx/ota/runners.py
@@ -239,7 +239,7 @@ class OtaExtract:
                         )
                     except UnsupportedOtaPayloadError:
                         logger.info(
-                            "Skipping unsupported OTA payload %s %s %s (current tooling cannot extract payloadv2 DSC)",
+                            "Skipping unsupported OTA payload %s %s %s (DSC referenced but current tooling cannot materialize it)",
                             ota.platform,
                             ota.version,
                             ota.build,

--- a/tests/test_extract_utils.py
+++ b/tests/test_extract_utils.py
@@ -14,6 +14,7 @@ import zipfile
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from pathlib import Path
+from subprocess import CompletedProcess
 from typing import BinaryIO, cast
 
 import pytest
@@ -35,14 +36,14 @@ from symx.ipsw.extract import (
     inspect_ipsw_product_metadata,
     map_platform_to_prefix,
 )
-from subprocess import CompletedProcess
-
-from symx.ota.model import DSCSearchResult, OtaExtractError
+from symx.ota.model import DSCSearchResult, OtaExtractError, OtaExtractionRequest, UnsupportedOtaPayloadError
 from symx.ota.extract import (
     DYLD_AA_INCLUDE_REGEX,
+    _dsc_entries_from_ipsw_listing,
     _probe_payload_with_aa,
     _probe_unsupported_payload_format,
     extract_ota,
+    extract_symbols,
     find_dsc,
     parse_cryptex_patch_output,
     parse_hdiutil_mount_output,
@@ -1331,3 +1332,132 @@ def test_probe_unsupported_payload_format_returns_false_when_payload_extracts(
     )
 
     assert _probe_unsupported_payload_format(artifact) is False
+
+
+def test_dsc_entries_from_ipsw_listing_parses_payload_and_bom_listing() -> None:
+    listing = (
+        "\n"
+        "- [ PAYLOAD FILES    ] --------------------------------------------------\n"
+        "\x1b[34m\x1b[1m   •\x1b[22m "
+        "System/Library/Caches/com.apple.dyld/dyld_shared_cache_arm64e\x1b[0m\n"
+        "- [ BOM FILES        ] --------------------------------------------------\n"
+        "      (OTA might not actually contain all these files if it is a partial update file)\n"
+        "\x1b[94m-rwxr-xr-x\x1b[0m "
+        "\x1b[2m2026-07-03T05:47:41+02:00\x1b[22m "
+        "\x1b[96m23 MB\x1b[0m   "
+        "\x1b[1mSystem/DriverKit/System/Library/dyld/dyld_shared_cache_arm64e\x1b[22m\n"
+        "-rwxr-xr-x 2026-07-03T05:47:41+02:00 131 MB  "
+        "System/Library/Caches/com.apple.dyld/dyld_shared_cache_arm64e.01\n"
+        "System/Library/Other/file\n"
+    )
+
+    assert _dsc_entries_from_ipsw_listing(listing) == [
+        "System/Library/Caches/com.apple.dyld/dyld_shared_cache_arm64e",
+        "System/DriverKit/System/Library/dyld/dyld_shared_cache_arm64e",
+        "System/Library/Caches/com.apple.dyld/dyld_shared_cache_arm64e.01",
+    ]
+
+
+def test_probe_unsupported_payload_format_returns_true_for_aea_with_dsc_listing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = Path("/tmp/test.aea")
+
+    monkeypatch.setattr("symx.ota.extract._ota_is_zip_archive", lambda artifact: False)
+    monkeypatch.setattr("symx.ota.extract._ota_is_aea_archive", lambda artifact: True)
+    monkeypatch.setattr(
+        "symx.ota.extract._probe_aea_payload_listing_for_dsc",
+        lambda artifact: {
+            "returncode": 0,
+            "stdout": "System/Library/Caches/com.apple.dyld/dyld_shared_cache_arm64e",
+            "stderr": None,
+            "dsc_entries": ["System/Library/Caches/com.apple.dyld/dyld_shared_cache_arm64e"],
+        },
+    )
+
+    assert _probe_unsupported_payload_format(artifact) is True
+
+
+def test_probe_unsupported_payload_format_returns_true_for_aea_with_bom_dsc_references(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = Path("/tmp/test.aea")
+
+    monkeypatch.setattr("symx.ota.extract._ota_is_zip_archive", lambda artifact: False)
+    monkeypatch.setattr("symx.ota.extract._ota_is_aea_archive", lambda artifact: True)
+    monkeypatch.setattr(
+        "symx.ota.extract._probe_aea_payload_listing_for_dsc",
+        lambda artifact: {
+            "returncode": 1,
+            "stdout": "- [ PAYLOAD FILES    ] --------------------------------------------------",
+            "stderr": "Invalid/non-supported archive stream",
+            "dsc_entries": [],
+        },
+    )
+    monkeypatch.setattr(
+        "symx.ota.extract._probe_aea_bom_listing_for_dsc",
+        lambda artifact: {
+            "returncode": 0,
+            "stdout": "System/Library/Caches/com.apple.dyld/dyld_shared_cache_arm64e",
+            "stderr": None,
+            "dsc_entries": ["System/Library/Caches/com.apple.dyld/dyld_shared_cache_arm64e"],
+        },
+    )
+
+    assert _probe_unsupported_payload_format(artifact) is True
+
+
+def test_probe_unsupported_payload_format_returns_false_for_aea_without_dsc_references(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = Path("/tmp/test.aea")
+
+    monkeypatch.setattr("symx.ota.extract._ota_is_zip_archive", lambda artifact: False)
+    monkeypatch.setattr("symx.ota.extract._ota_is_aea_archive", lambda artifact: True)
+    monkeypatch.setattr(
+        "symx.ota.extract._probe_aea_payload_listing_for_dsc",
+        lambda artifact: {
+            "returncode": 1,
+            "stdout": "- [ PAYLOAD FILES    ] --------------------------------------------------",
+            "stderr": "Invalid/non-supported archive stream",
+            "dsc_entries": [],
+        },
+    )
+    monkeypatch.setattr(
+        "symx.ota.extract._probe_aea_bom_listing_for_dsc",
+        lambda artifact: {
+            "returncode": 0,
+            "stdout": "- [ BOM FILES        ] --------------------------------------------------",
+            "stderr": None,
+            "dsc_entries": [],
+        },
+    )
+
+    assert _probe_unsupported_payload_format(artifact) is False
+
+
+def test_extract_symbols_classifies_aea_dsc_listing_extracting_no_dsc_as_unsupported(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    artifact = tmp_path / "test.aea"
+    artifact.write_bytes(b"AEA1")
+    request = OtaExtractionRequest(
+        local_ota=artifact,
+        work_dir=tmp_path / "work",
+        platform="visionos",
+        version="27.0",
+        build="24M5316k",
+        bundle_id="ota_test",
+    )
+
+    monkeypatch.setattr(
+        "symx.ota.extract.extract_ota",
+        lambda artifact, output_dir: (_ for _ in ()).throw(
+            OtaExtractError(f"OTA extraction produced no dyld_shared_cache files for {artifact}")
+        ),
+    )
+    monkeypatch.setattr("symx.ota.extract._classify_ota_failure", lambda artifact: None)
+    monkeypatch.setattr("symx.ota.extract._probe_unsupported_payload_format", lambda artifact: True)
+
+    with pytest.raises(UnsupportedOtaPayloadError):
+        extract_symbols(request)

--- a/tests/test_extract_utils.py
+++ b/tests/test_extract_utils.py
@@ -1450,6 +1450,7 @@ def test_extract_symbols_classifies_aea_dsc_listing_extracting_no_dsc_as_unsuppo
         bundle_id="ota_test",
     )
 
+    monkeypatch.setattr("symx.ota.extract.patch_cryptex_dmg", lambda artifact, output_dir: {})
     monkeypatch.setattr(
         "symx.ota.extract.extract_ota",
         lambda artifact, output_dir: (_ for _ in ()).throw(


### PR DESCRIPTION
For non-ZIP AEA OTAs, after extraction has already failed:

1. probe payload listing for DSC entries,
2. fall back to BOM listing,
3. if DSC references are found but current tooling cannot materialize them, raise `UnsupportedOtaPayloadError`,
4. the runner records `unsupported_ota_payload`.

I did this because recent OTA extraction runs produced generic symbol extraction failures for `AEA` payloads where:

- direct `ipsw ota extract` produced no DSC files
- `ipsw ota ls --payload --pattern dyld_shared_cache` fails with `AA` parser errors, and
- `ipsw ota ls --bom` references `dyld_shared_cache` paths.

This is similar to #56: high-level `ipsw` commands collapse or mask lower-level failure phases. In this case, `ipsw ota extract -p` can return successfully while materializing no files, so we previously only saw an empty output tree.